### PR TITLE
Fix to raise an error if the specific library can't be found. 

### DIFF
--- a/lib/oci8.rb.in
+++ b/lib/oci8.rb.in
@@ -1,4 +1,3 @@
-
 #   --*- ruby -*--
 # This is based on yoshidam's oracle.rb.
 #
@@ -41,7 +40,13 @@ if ruby_engine == 'ruby'
 else
   so_basename += ruby_engine
 end
-require so_basename
+
+begin
+  require so_basename
+rescue LoadError => e
+  puts "Unable to load #{so_basename}.so"
+  puts e.message
+end
 
 if OCI8::VERSION != '@@OCI8_MODULE_VERSION@@'
   require 'rbconfig'


### PR DESCRIPTION
I had this problem on Ubuntu when libaio1 was not installed.  Because the exception was not handled, when I loaded ruby-plsql, the error message did not give enough details about the problem, so it took a while to debug.  This will make it easier to debug problems.  I'm also submitting a pull request to ruby-plsql, because it doesn't handle the error either.
