### PR TITLE
bind_param: when value is nil, use String as default type 

### DIFF
--- a/lib/oci8/cursor.rb
+++ b/lib/oci8/cursor.rb
@@ -89,6 +89,10 @@ class OCI8
     #   cursor.exec()
     #   cursor.close()
     def bind_param(key, param, type = nil, length = nil)
+      if type.nil? and param.nil?
+        type = String
+        length = 1 unless length
+      end
       case param
       when Hash
       when Class
@@ -288,18 +292,19 @@ class OCI8
         raise "all binding arrays should be the same size." unless @actual_array_size.nil? || var_array.size == @actual_array_size
         @actual_array_size = var_array.size if @actual_array_size.nil?
       end
-      
+
       param = {:value => var_array, :type => type, :length => max_item_length, :max_array_size => @max_array_size}
       first_non_nil_elem = var_array.nil? ? nil : var_array.find{|x| x!= nil}
-      
+
       if type.nil?
         if first_non_nil_elem.nil?
-          raise "bind type is not given."
+          type = String #raise "bind type is not given."
+          max_item_length = 1 unless max_item_length
         else
           type = first_non_nil_elem.class
         end
       end
-      
+
       bindclass = OCI8::BindType::Mapping[type]
       if bindclass.nil? and type.is_a? Class
         bindclass = OCI8::BindType::Mapping[type.to_s]


### PR DESCRIPTION
Looking at DBD code, I've seen that when bind values are null, they are mapped using String as default type.
I don't know the drawback of this approach (reliability? performances?) but it is really convenient in many cases.

Why shouldn't we use String as default type when the value is nil and no type info is provided ?
