### PR TITLE
Fix typo

### DIFF
--- a/lib/ruby-oci8.rb
+++ b/lib/ruby-oci8.rb
@@ -1,4 +1,4 @@
 if caller[0] !~ /\/bundler\/runtime\.rb:\d+:in `require'/
-  warn "Don't requie 'ruby-oci8'. Use \"require 'oci8'\" instead. 'ruby-oci8.rb' was added only for 'Bundler.require'."
+  warn "Don't require 'ruby-oci8'. Use \"require 'oci8'\" instead. 'ruby-oci8.rb' was added only for 'Bundler.require'."
 end
 require 'oci8'


### PR DESCRIPTION
Just a small typo I noticed when I happened to require 'ruby-oci8' instead of 'oci8'.