### PR TITLE
Fix invalid value for BigDecimal in Ruby 2.4.0+

### DIFF
--- a/ext/oci8/ocinumber.c
+++ b/ext/oci8/ocinumber.c
@@ -1429,7 +1429,7 @@ static VALUE onum_to_d_real(OCINumber *num, OCIError *errhp)
 {
     char buf[64];
     ub4 buf_size = sizeof(buf);
-    const char *fmt = "FM9.99999999999999999999999999999999999999EEEE";
+    const char *fmt = "FM9.09999999999999999999999999999999999999EEEE";
 
     if (!cBigDecimal) {
         rb_require("bigdecimal");


### PR DESCRIPTION
Fix https://github.com/kubo/ruby-oci8/issues/143 .

BigDecimal has changed that raise error for an invalid string for `BigDecimal()` in Ruby 2.4.0 RC1.

https://github.com/ruby/bigdecimal/commit/3081a627cebdc1fc119425c7a9f009dbb6bec8e8

## Before (Ruby 2.3.3)

We can use both `"1.E+00"` and `"1.0E+00"` for `BigDecimal()`.

```ruby
require "bigdecimal"
BigDecimal("1.E+00").to_s #=> "0.1E1"
BigDecimal("1.E+00") == BigDecimal("1.0E+00") #=> true
```

## After (Ruby 2.4.0 RC1)

We can not use `"1.E+00"` that will result `ArgumentError`.

```ruby
require "bigdecimal"
BigDecimal("1.E+00") #=> ArgumentError: invalid value for BigDecimal(): "1.E+00"
BigDecimal("1.0E+00") #=> 0.1e1
```

This PR has change below.

Previously used format of `to_char`:

```ruby
OraNumber(1).to_char('FM9.99999999999999999999999999999999999999EEEE') #=> "1.E+00"
```

This PR used format of `to_char`:

```ruby
OraNumber(1).to_char('FM9.09999999999999999999999999999999999999EEEE') #=> "1.0E+00"
```

See also, I'm asking questions about `BigDecimal()` change.

https://github.com/ruby/bigdecimal/issues/47 .

By the way, I think that this PR change using `"1.0E+00"` is better, maybe.

Related issue: https://github.com/rsim/oracle-enhanced/issues/1085

Thanks.