### PR TITLE
Integer Unification in Ruby 2.4.0+

### DIFF
--- a/ext/oci8/encoding.c
+++ b/ext/oci8/encoding.c
@@ -23,7 +23,7 @@ rb_encoding *oci8_encoding;
  * Returns the Oracle character set name from the specified
  * character set ID if it is valid. Otherwise, +nil+ is returned.
  *
- * @param [Fixnum] charset_id   Oracle character set id
+ * @param [Integer] charset_id  Oracle character set id
  * @return [String]             Oracle character set name or nil
  * @since 2.2.0
  */
@@ -48,7 +48,7 @@ VALUE oci8_s_charset_id2name(VALUE klass, VALUE csid)
  * character set name if it is valid. Othewise, +nil+ is returned.
  *
  * @param [String] charset_name   Oracle character set name
- * @return [Fixnum]               Oracle character set id or nil
+ * @return [Integer]              Oracle character set id or nil
  * @since 2.2.0
  */
 static VALUE oci8_s_charset_name2id(VALUE klass, VALUE name)
@@ -71,7 +71,7 @@ static VALUE oci8_s_charset_name2id(VALUE klass, VALUE name)
  * internal buffer size of a string bind variable whose nls length
  * semantics is char.
  *
- * @return [Fixnum]  NLS ratio
+ * @return [Integer] NLS ratio
  * @since 2.1.0
  * @private
  */
@@ -150,7 +150,7 @@ static VALUE oci8_set_encoding(VALUE klass, VALUE encoding)
  * character set name if it is valid. Othewise, +nil+ is returned.
  *
  * @param [String] charset_name   Oracle character set name
- * @return [Fixnum]               Oracle character set id or nil
+ * @return [Integer]              Oracle character set id or nil
  * @since 2.0.0
  * @deprecated Use {OCI8.charset_name2id} instead.
  */
@@ -167,7 +167,7 @@ static VALUE oci8_charset_name2id(VALUE svc, VALUE name)
  * Returns the Oracle character set name from the specified
  * character set ID if it is valid. Otherwise, +nil+ is returned.
  *
- * @param [Fixnum] charset_id   Oracle character set id
+ * @param [Integer] charset_id  Oracle character set id
  * @return [String]             Oracle character set name or nil
  * @since 2.0.0
  * @deprecated Use {OCI8.charset_id2name} instead.

--- a/ext/oci8/oci8.c
+++ b/ext/oci8/oci8.c
@@ -286,7 +286,7 @@ static VALUE oci8_s_oracle_client_vernum(VALUE klass)
 /*
  * @overload OCI8.__get_prop(key)
  *
- *  @param [Fixnum] key    1, 2 or 3
+ *  @param [Integer] key   1, 2 or 3
  *  @return [Object]       depends on +key+.
  *  @private
  */
@@ -306,7 +306,7 @@ static VALUE oci8_s_get_prop(VALUE klass, VALUE key)
 /*
  * @overload OCI8.__set_prop(key, value)
  *
- *  @param [Fixnum] key    1, 2 or 3
+ *  @param [Integer] key   1, 2 or 3
  *  @param [Object] value  depends on +key+.
  *
  *  @private
@@ -359,7 +359,7 @@ static VALUE oci8_s_set_prop(VALUE klass, VALUE key, VALUE val)
  *    # When NLS_LANG is FRENCH_FRANCE.AL32UTF8
  *    OCI8.error_message(1) # => "ORA-00001: violation de contrainte unique (%s.%s)"
  *
- *  @param [Fixnum] message_no   Oracle error message number
+ *  @param [Integer] message_no  Oracle error message number
  *  @return [String]             Oracle error message
  */
 static VALUE oci8_s_error_message(VALUE klass, VALUE msgid)
@@ -668,8 +668,8 @@ static VALUE oci8_server_attach(VALUE self, VALUE dbname, VALUE attach_mode)
  *
  *  Begins the session by the OCI function OCISessionBegin().
  *
- *  @param [Fixnum] cred
- *  @param [Fixnum] mode
+ *  @param [Integer] cred
+ *  @param [Integer] mode
  *  @private
  */
 static VALUE oci8_session_begin(VALUE self, VALUE cred, VALUE mode)

--- a/ext/oci8/ocihandle.c
+++ b/ext/oci8/ocihandle.c
@@ -245,9 +245,9 @@ static VALUE attr_get_common(int argc, VALUE *argv, VALUE self, enum datatype da
  *
  *  Gets the value of an attribute as `ub1' datatype.
  *
- *  @param [Fixnum] attr_type
+ *  @param [Integer] attr_type
  *  @param [Boolean] strict If false, "ORA-24328: illegal attribute value" is ignored.
- *  @return [Fixnum]
+ *  @return [Integer]
  *
  *  @since 2.0.4
  *  @private
@@ -262,9 +262,9 @@ static VALUE attr_get_ub1(int argc, VALUE *argv, VALUE self)
  *
  *  Gets the value of an attribute as `ub2' datatype.
  *
- *  @param [Fixnum] attr_type
+ *  @param [Integer] attr_type
  *  @param [Boolean] strict If false, "ORA-24328: illegal attribute value" is ignored.
- *  @return [Fixnum]
+ *  @return [Integer]
  *
  *  @since 2.0.4
  *  @private
@@ -279,7 +279,7 @@ static VALUE attr_get_ub2(int argc, VALUE *argv, VALUE self)
  *
  *  Gets the value of an attribute as `ub4' datatype.
  *
- *  @param [Fixnum] attr_type
+ *  @param [Integer] attr_type
  *  @param [Boolean] strict If false, "ORA-24328: illegal attribute value" is ignored.
  *  @return [Integer]
  *
@@ -296,7 +296,7 @@ static VALUE attr_get_ub4(int argc, VALUE *argv, VALUE self)
  *
  *  Gets the value of an attribute as `ub8' datatype.
  *
- *  @param [Fixnum] attr_type
+ *  @param [Integer] attr_type
  *  @param [Boolean] strict If false, "ORA-24328: illegal attribute value" is ignored.
  *  @return [Integer]
  *
@@ -313,9 +313,9 @@ static VALUE attr_get_ub8(int argc, VALUE *argv, VALUE self)
  *
  *  Gets the value of an attribute as `sb1' datatype.
  *
- *  @param [Fixnum] attr_type
+ *  @param [Integer] attr_type
  *  @param [Boolean] strict If false, "ORA-24328: illegal attribute value" is ignored.
- *  @return [Fixnum]
+ *  @return [Integer]
  *
  *  @since 2.0.4
  *  @private
@@ -330,9 +330,9 @@ static VALUE attr_get_sb1(int argc, VALUE *argv, VALUE self)
  *
  *  Gets the value of an attribute as `sb2' datatype.
  *
- *  @param [Fixnum] attr_type
+ *  @param [Integer] attr_type
  *  @param [Boolean] strict If false, "ORA-24328: illegal attribute value" is ignored.
- *  @return [Fixnum]
+ *  @return [Integer]
  *
  *  @since 2.0.4
  *  @private
@@ -347,7 +347,7 @@ static VALUE attr_get_sb2(int argc, VALUE *argv, VALUE self)
  *
  *  Gets the value of an attribute as `sb4' datatype.
  *
- *  @param [Fixnum] attr_type
+ *  @param [Integer] attr_type
  *  @param [Boolean] strict If false, "ORA-24328: illegal attribute value" is ignored.
  *  @return [Integer]
  *
@@ -364,7 +364,7 @@ static VALUE attr_get_sb4(int argc, VALUE *argv, VALUE self)
  *
  *  Gets the value of an attribute as `sb8' datatype.
  *
- *  @param [Fixnum] attr_type
+ *  @param [Integer] attr_type
  *  @param [Boolean] strict If false, "ORA-24328: illegal attribute value" is ignored.
  *  @return [Integer]
  *
@@ -381,7 +381,7 @@ static VALUE attr_get_sb8(int argc, VALUE *argv, VALUE self)
  *
  *  Gets the value of an attribute as `boolean' datatype.
  *
- *  @param [Fixnum] attr_type
+ *  @param [Integer] attr_type
  *  @param [Boolean] strict If false, "ORA-24328: illegal attribute value" is ignored.
  *  @return [true of false]
  *
@@ -403,7 +403,7 @@ static VALUE attr_get_boolean(int argc, VALUE *argv, VALUE self)
  *  @note If the specified attr_type's datatype is not a
  *    pointer type, it causes a segmentation fault.
  *
- *  @param [Fixnum] attr_type
+ *  @param [Integer] attr_type
  *  @param [Boolean] strict If false, "ORA-24328: illegal attribute value" is ignored.
  *  @return [String]
  *
@@ -424,7 +424,7 @@ static VALUE attr_get_string(int argc, VALUE *argv, VALUE self)
  *  @note If the specified attr_type's datatype is not a
  *    pointer type, it causes a segmentation fault.
  *
- *  @param [Fixnum] attr_type
+ *  @param [Integer] attr_type
  *  @param [Boolean] strict If false, "ORA-24328: illegal attribute value" is ignored.
  *  @return [String]
  *
@@ -445,9 +445,9 @@ static VALUE attr_get_binary(int argc, VALUE *argv, VALUE self)
  *  @note If the specified attr_type's datatype is not a
  *    pointer type, it causes a segmentation fault.
  *
- *  @param [Fixnum] attr_type
+ *  @param [Integer] attr_type
  *  @param [Boolean] strict If false, "ORA-24328: illegal attribute value" is ignored.
- *  @return [Fixnum]
+ *  @return [Integer]
  *
  *  @since 2.0.4
  *  @private
@@ -466,7 +466,7 @@ static VALUE attr_get_integer(int argc, VALUE *argv, VALUE self)
  *  @note If the specified attr_type's datatype is not a
  *    pointer type, it causes a segmentation fault.
  *
- *  @param [Fixnum] attr_type
+ *  @param [Integer] attr_type
  *  @param [Boolean] strict If false, "ORA-24328: illegal attribute value" is ignored.
  *  @return [OraDate]
  *
@@ -486,8 +486,8 @@ static VALUE attr_get_oradate(int argc, VALUE *argv, VALUE self)
  *  @note If the specified attr_type's datatype is a
  *    pointer type, it causes a segmentation fault.
  *
- *  @param [Fixnum] attr_type
- *  @param [Fixnum] attr_value
+ *  @param [Integer] attr_type
+ *  @param [Integer] attr_value
  *  @return [self]
  *
  *  @since 2.0.4
@@ -514,8 +514,8 @@ static VALUE attr_set_ub1(VALUE self, VALUE attr_type, VALUE val)
  *  @note If the specified attr_type's datatype is a
  *    pointer type, it causes a segmentation fault.
  *
- *  @param [Fixnum] attr_type
- *  @param [Fixnum] attr_value
+ *  @param [Integer] attr_type
+ *  @param [Integer] attr_value
  *  @return [self]
  *
  *  @since 2.0.4
@@ -542,7 +542,7 @@ static VALUE attr_set_ub2(VALUE self, VALUE attr_type, VALUE val)
  *  @note If the specified attr_type's datatype is a
  *    pointer type, it causes a segmentation fault.
  *
- *  @param [Fixnum] attr_type
+ *  @param [Integer] attr_type
  *  @param [Integer] attr_value
  *  @return [self]
  *
@@ -570,7 +570,7 @@ static VALUE attr_set_ub4(VALUE self, VALUE attr_type, VALUE val)
  *  @note If the specified attr_type's datatype is a
  *    pointer type, it causes a segmentation fault.
  *
- *  @param [Fixnum] attr_type
+ *  @param [Integer] attr_type
  *  @param [Integer] attr_value
  *  @return [self]
  *
@@ -598,8 +598,8 @@ static VALUE attr_set_ub8(VALUE self, VALUE attr_type, VALUE val)
  *  @note If the specified attr_type's datatype is a
  *    pointer type, it causes a segmentation fault.
  *
- *  @param [Fixnum] attr_type
- *  @param [Fixnum] attr_value
+ *  @param [Integer] attr_type
+ *  @param [Integer] attr_value
  *  @return [self]
  *
  *  @since 2.0.4
@@ -626,8 +626,8 @@ static VALUE attr_set_sb1(VALUE self, VALUE attr_type, VALUE val)
  *  @note If the specified attr_type's datatype is a
  *   pointer type, it causes a segmentation fault.
  *
- *  @param [Fixnum] attr_type
- *  @param [Fixnum] attr_value
+ *  @param [Integer] attr_type
+ *  @param [Integer] attr_value
  *  @return [self]
  *
  *  @since 2.0.4
@@ -654,7 +654,7 @@ static VALUE attr_set_sb2(VALUE self, VALUE attr_type, VALUE val)
  *  @note If the specified attr_type's datatype is a
  *    pointer type, it causes a segmentation fault.
  *
- *  @param [Fixnum] attr_type
+ *  @param [Integer] attr_type
  *  @param [Integer] attr_value
  *  @return [self]
  *
@@ -682,7 +682,7 @@ static VALUE attr_set_sb4(VALUE self, VALUE attr_type, VALUE val)
  *  @note If the specified attr_type's datatype is a
  *    pointer type, it causes a segmentation fault.
  *
- *  @param [Fixnum] attr_type
+ *  @param [Integer] attr_type
  *  @param [Integer] attr_value
  *  @return [self]
  *
@@ -710,7 +710,7 @@ static VALUE attr_set_sb8(VALUE self, VALUE attr_type, VALUE val)
  *  @note If the specified attr_type's datatype is a
  *    pointer type, it causes a segmentation fault.
  *
- *  @param [Fixnum] attr_type
+ *  @param [Integer] attr_type
  *  @param [true or false] attr_value
  *  @return [self]
  *
@@ -737,7 +737,7 @@ static VALUE attr_set_boolean(VALUE self, VALUE attr_type, VALUE val)
  *  +attr_value+ is converted to {OCI8.encoding} before it is set
  *  when the ruby version is 1.9.
  *
- *  @param [Fixnum] attr_type
+ *  @param [Integer] attr_type
  *  @param [String] attr_value
  *  @return [self]
  *
@@ -761,7 +761,7 @@ static VALUE attr_set_string(VALUE self, VALUE attr_type, VALUE val)
  *
  *  Sets the value of an attribute as `ub1 *' datatype.
  *
- *  @param [Fixnum] attr_type
+ *  @param [Integer] attr_type
  *  @param [String] attr_value
  *  @return [self]
  *
@@ -787,7 +787,7 @@ static VALUE attr_set_binary(VALUE self, VALUE attr_type, VALUE val)
  *  +number+ is converted to internal Oracle NUMBER format before
  *  it is set.
  *
- *  @param [Fixnum] attr_type
+ *  @param [Integer] attr_type
  *  @param [Numeric] number
  *  @return [self]
  *

--- a/ext/oci8/oraconf.rb
+++ b/ext/oci8/oraconf.rb
@@ -384,7 +384,7 @@ EOS
                         [nil].pack('P').size
                       rescue ArgumentError
                         # Rubinius 1.2.3 doesn't support Array#pack('P').
-                        # Use Fixnum#size, which returns the size of long.
+                        # Use Integer#size, which returns the size of long.
                         1.size
                       end
     is_32bit = size_of_pointer == 4

--- a/ext/oci8/oradate.c
+++ b/ext/oci8/oradate.c
@@ -116,12 +116,12 @@ static VALUE ora_date_s_allocate(VALUE klass)
  *    OraDate.new(2012)        # => 2012-01-01 00:00:00
  *    OraDate.new(2012, 3, 4)  # => 2012-03-04 00:00:00
  *
- *  @param [Fixnum] year year
- *  @param [Fixnum] month month
- *  @param [Fixnum] day  day of month
- *  @param [Fixnum] hour hour
- *  @param [Fixnum] min  minute
- *  @param [Fixnum] sec  second
+ *  @param [Integer] year year
+ *  @param [Integer] month month
+ *  @param [Integer] day  day of month
+ *  @param [Integer] hour hour
+ *  @param [Integer] min  minute
+ *  @param [Integer] sec  second
  */
 static VALUE ora_date_initialize(int argc, VALUE *argv, VALUE self)
 {
@@ -267,7 +267,7 @@ static VALUE ora_date_to_a(VALUE self)
  *
  *  Returns the year field of <i>self</i>.
  *
- *  @return [Fixnum]
+ *  @return [Integer]
  */
 static VALUE ora_date_year(VALUE self)
 {
@@ -281,7 +281,7 @@ static VALUE ora_date_year(VALUE self)
  *
  *  Assigns <i>num</i> to the year field of <i>self</i>.
  *
- *  @param [Fixnum] num number between -4712 and 9999
+ *  @param [Integer] num number between -4712 and 9999
  */
 static VALUE ora_date_set_year(VALUE self, VALUE val)
 {
@@ -299,7 +299,7 @@ static VALUE ora_date_set_year(VALUE self, VALUE val)
  *  Returns the month field of <i>self</i>.
  *  The month starts with one.
  *
- *  @return [Fixnum]
+ *  @return [Integer]
  */
 static VALUE ora_date_month(VALUE self)
 {
@@ -314,7 +314,7 @@ static VALUE ora_date_month(VALUE self)
  *  Assigns <i>num</i> to the month field of <i>self</i>.
  *  The month starts with one.
  *
- *  @param [Fixnum] num number between 1 and 12
+ *  @param [Integer] num number between 1 and 12
  */
 static VALUE ora_date_set_month(VALUE self, VALUE val)
 {
@@ -331,7 +331,7 @@ static VALUE ora_date_set_month(VALUE self, VALUE val)
  *
  *  Returns the day of month field of <i>self</i>.
  *
- *  @return [Fixnum]
+ *  @return [Integer]
  */
 static VALUE ora_date_day(VALUE self)
 {
@@ -345,7 +345,7 @@ static VALUE ora_date_day(VALUE self)
  *
  *  Assigns <i>num</i> to the day of month field of <i>self</i>.
  *
- *  @param [Fixnum] num number between 1 and 31
+ *  @param [Integer] num number between 1 and 31
  */
 static VALUE ora_date_set_day(VALUE self, VALUE val)
 {
@@ -362,7 +362,7 @@ static VALUE ora_date_set_day(VALUE self, VALUE val)
  *
  *  Returns the hour field of <i>self</i>.
  *
- *  @return [Fixnum]
+ *  @return [Integer]
  */
 static VALUE ora_date_hour(VALUE self)
 {
@@ -376,7 +376,7 @@ static VALUE ora_date_hour(VALUE self)
  *
  *  Assigns <i>num</i> to the hour field of <i>self</i>.
  *
- *  @param [Fixnum] num number between 0 and 23
+ *  @param [Integer] num number between 0 and 23
  */
 static VALUE ora_date_set_hour(VALUE self, VALUE val)
 {
@@ -393,7 +393,7 @@ static VALUE ora_date_set_hour(VALUE self, VALUE val)
  *
  *  Returns the minute field of <i>self</i>.
  *
- *  @return [Fixnum]
+ *  @return [Integer]
  */
 static VALUE ora_date_minute(VALUE self)
 {
@@ -407,7 +407,7 @@ static VALUE ora_date_minute(VALUE self)
  *
  *  Assigns <i>num</i> to the minute field of <i>self</i>.
  *
- *  @param [Fixnum] num number between 0 and 59
+ *  @param [Integer] num number between 0 and 59
  */
 static VALUE ora_date_set_minute(VALUE self, VALUE val)
 {
@@ -424,7 +424,7 @@ static VALUE ora_date_set_minute(VALUE self, VALUE val)
  *
  *  Returns the second field of <i>self</i>.
  *
- *  @return [Fixnum]
+ *  @return [Integer]
  */
 static VALUE ora_date_second(VALUE self)
 {
@@ -438,7 +438,7 @@ static VALUE ora_date_second(VALUE self)
  *
  *  Assigns <i>num</i> to the second field of <i>self</i>.
  *
- *  @param [Fixnum] num number between 0 and 59
+ *  @param [Integer] num number between 0 and 59
  */
 static VALUE ora_date_set_second(VALUE self, VALUE val)
 {

--- a/ext/oci8/stmt.c
+++ b/ext/oci8/stmt.c
@@ -288,7 +288,7 @@ static VALUE oci8_stmt_fetch(VALUE self, VALUE svc)
  *
  *  Returns the definition of column specified by <i>pos</i>
  *
- *  @param [Fixnum] pos Column position which starts from one
+ *  @param [Integer] pos Column position which starts from one
  *  @return [OCI8::Metadata::Base]
  *
  *  @private

--- a/lib/oci8/bindtype.rb
+++ b/lib/oci8/bindtype.rb
@@ -199,26 +199,32 @@ class OCI8
 end
 
 # bind or explicitly define
-OCI8::BindType::Mapping[String]       = OCI8::BindType::String
-OCI8::BindType::Mapping[OraNumber]    = OCI8::BindType::OraNumber
-OCI8::BindType::Mapping['BigDecimal'] = OCI8::BindType::BigDecimal
-OCI8::BindType::Mapping['Rational']   = OCI8::BindType::Rational
-OCI8::BindType::Mapping[Fixnum]       = OCI8::BindType::Integer
-OCI8::BindType::Mapping[Float]        = OCI8::BindType::Float
-OCI8::BindType::Mapping[Integer]      = OCI8::BindType::Integer
-OCI8::BindType::Mapping[Bignum]       = OCI8::BindType::Integer
-OCI8::BindType::Mapping[OraDate]      = OCI8::BindType::OraDate
-OCI8::BindType::Mapping[Time]         = OCI8::BindType::Time
-OCI8::BindType::Mapping[Date]         = OCI8::BindType::Date
-OCI8::BindType::Mapping[DateTime]     = OCI8::BindType::DateTime
-OCI8::BindType::Mapping[OCI8::CLOB]   = OCI8::BindType::CLOB
-OCI8::BindType::Mapping[OCI8::NCLOB]  = OCI8::BindType::NCLOB
-OCI8::BindType::Mapping[OCI8::BLOB]   = OCI8::BindType::BLOB
-OCI8::BindType::Mapping[OCI8::BFILE]  = OCI8::BindType::BFILE
-OCI8::BindType::Mapping[OCI8::Cursor] = OCI8::BindType::Cursor
+OCI8::BindType::Mapping[String]          = OCI8::BindType::String
+OCI8::BindType::Mapping[OraNumber]       = OCI8::BindType::OraNumber
+OCI8::BindType::Mapping['BigDecimal']    = OCI8::BindType::BigDecimal
+OCI8::BindType::Mapping['Rational']      = OCI8::BindType::Rational
+unless 0.class == Integer
+  # Ruby 2.3 or lower it need to bind with Fixnum
+  OCI8::BindType::Mapping[0.class]       = OCI8::BindType::Integer
+end
+OCI8::BindType::Mapping[Float]           = OCI8::BindType::Float
+OCI8::BindType::Mapping[Integer]         = OCI8::BindType::Integer
+unless (2**64).class == Integer
+  # Ruby 2.3 or lower it need to bind with Bignum
+  OCI8::BindType::Mapping[(2**64).class] = OCI8::BindType::Integer
+end
+OCI8::BindType::Mapping[OraDate]         = OCI8::BindType::OraDate
+OCI8::BindType::Mapping[Time]            = OCI8::BindType::Time
+OCI8::BindType::Mapping[Date]            = OCI8::BindType::Date
+OCI8::BindType::Mapping[DateTime]        = OCI8::BindType::DateTime
+OCI8::BindType::Mapping[OCI8::CLOB]      = OCI8::BindType::CLOB
+OCI8::BindType::Mapping[OCI8::NCLOB]     = OCI8::BindType::NCLOB
+OCI8::BindType::Mapping[OCI8::BLOB]      = OCI8::BindType::BLOB
+OCI8::BindType::Mapping[OCI8::BFILE]     = OCI8::BindType::BFILE
+OCI8::BindType::Mapping[OCI8::Cursor]    = OCI8::BindType::Cursor
 if defined? OCI8::BindType::Boolean
-  OCI8::BindType::Mapping[TrueClass] = OCI8::BindType::Boolean
-  OCI8::BindType::Mapping[FalseClass] = OCI8::BindType::Boolean
+  OCI8::BindType::Mapping[TrueClass]     = OCI8::BindType::Boolean
+  OCI8::BindType::Mapping[FalseClass]    = OCI8::BindType::Boolean
 end
 
 # implicitly define

--- a/lib/oci8/compat.rb
+++ b/lib/oci8/compat.rb
@@ -70,7 +70,7 @@ class OCI8
   constants.each do |name|
     next if name.to_s.index("SQLT_") != 0
     val = const_get name.intern
-    if val.is_a? Fixnum
+    if val.is_a? Integer
       SQLT_NAMES[val] = name
     end
   end
@@ -80,21 +80,21 @@ class OCI8
 
   class Cursor
     def self.select_number_as=(val)
-      if val == Fixnum
-        @@bind_unknown_number = OCI8::BindType::Fixnum
+      if val == Integer
+        @@bind_unknown_number = OCI8::BindType::Integer
       elsif val == Integer
         @@bind_unknown_number = OCI8::BindType::Integer
       elsif val == Float
         @@bind_unknown_number = OCI8::BindType::Float
       else
-        raise ArgumentError, "must be Fixnum, Integer or Float"
+        raise ArgumentError, "must be Integer, Integer or Float"
       end
     end
 
     def self.select_number_as
       case @@bind_unknown_number
-      when OCI8::BindType::Fixnum
-        return Fixnum
+      when OCI8::BindType::Integer
+        return Integer
       when OCI8::BindType::Integer
         return Integer
       when OCI8::BindType::Float
@@ -108,6 +108,9 @@ class OCI8
 
   module BindType
     # alias to Integer for compatibility with ruby-oci8 1.0.
-    Fixnum = Integer
+    unless 0.class == Integer
+      fixnum = 0.class
+      fixnum = Integer
+    end
   end
 end

--- a/lib/oci8/cursor.rb
+++ b/lib/oci8/cursor.rb
@@ -63,9 +63,9 @@ class OCI8
     # +type+ and Fixnum or Float to +val+.
     #
     # example:
-    #   cursor.bind_param(1, 1234) # bind as Fixnum, Initial value is 1234.
+    #   cursor.bind_param(1, 1234) # bind as Integer, Initial value is 1234.
     #   cursor.bind_param(1, 1234.0) # bind as Float, Initial value is 1234.0.
-    #   cursor.bind_param(1, nil, Fixnum) # bind as Fixnum, Initial value is NULL.
+    #   cursor.bind_param(1, nil, Integer) # bind as Integer, Initial value is NULL.
     #   cursor.bind_param(1, nil, Float) # bind as Float, Initial value is NULL.
     #
     # In case of binding a string, set the string itself to
@@ -379,7 +379,7 @@ class OCI8
     #
     # FYI: Rails oracle adaptor uses 100 by default.
     #
-    # @param [Fixnum] rows The number of rows to be prefetched
+    # @param [Integer] rows The number of rows to be prefetched
     def prefetch_rows=(rows)
       attr_set_ub4(11, rows) # OCI_ATTR_PREFETCH_ROWS(11)
     end
@@ -430,12 +430,12 @@ class OCI8
     # * OCI8::STMT_ALTER
     # * OCI8::STMT_BEGIN (PL/SQL block which starts with a BEGIN keyword)
     # * OCI8::STMT_DECLARE (PL/SQL block which starts with a DECLARE keyword)
-    # * Other Fixnum value undocumented in Oracle manuals.
+    # * Other Integer value undocumented in Oracle manuals.
     #
     # <em>Changes between ruby-oci8 1.0 and 2.0.</em>
     #
     # [ruby-oci8 2.0] OCI8::STMT_* are Symbols. (:select_stmt, :update_stmt, etc.)
-    # [ruby-oci8 1.0] OCI8::STMT_* are Fixnums. (1, 2, 3, etc.)
+    # [ruby-oci8 1.0] OCI8::STMT_* are Integers. (1, 2, 3, etc.)
     #
     def type
       # http://docs.oracle.com/cd/E11882_01/appdev.112/e10646/ociaahan.htm#sthref5506

--- a/lib/oci8/oci8.rb
+++ b/lib/oci8/oci8.rb
@@ -622,7 +622,7 @@ class OCIError
   #
   def initialize(*args)
     if args.length > 0
-      if args[0].is_a? Fixnum
+      if args[0].is_a? Integer
         @code = args.shift
         super(OCI8.error_message(@code).gsub('%s') {|s| args.empty? ? '%s' : args.shift})
         @sql = nil

--- a/spec/oranumber_spec.rb
+++ b/spec/oranumber_spec.rb
@@ -38,37 +38,37 @@ describe OraNumber do
     (OraNumber(2) / OraNumber(1)).should eql(OraNumber(2))
   end
 
-  # OraNumber bin_op Fixnum
-  it "+ Fixnum should be an OraNumber" do
+  # OraNumber bin_op Integer
+  it "+ Integer should be an OraNumber" do
     (OraNumber(2) + 1).should eql(OraNumber(3))
   end
 
-  it "- Fixnum should be an OraNumber" do
+  it "- Integer should be an OraNumber" do
     (OraNumber(2) - 1).should eql(OraNumber(1))
   end
 
-  it "* Fixnum should be an OraNumber" do
+  it "* Integer should be an OraNumber" do
     (OraNumber(2) * 1).should eql(OraNumber(2))
   end
 
-  it "/ Fixnum should be an OraNumber" do
+  it "/ Integer should be an OraNumber" do
     (OraNumber(2) / 1).should eql(OraNumber(2))
   end
 
-  # OraNumber bin_op Bignum
-  it "+ Bignum should be an OraNumber" do
+  # OraNumber bin_op Integer
+  it "+ Integer should be an OraNumber" do
     (OraNumber(2) + 100000000000000000000).should eql(OraNumber(100000000000000000002))
   end
 
-  it "- Bignum should be an OraNumber" do
+  it "- Integer should be an OraNumber" do
     (OraNumber(2) - 100000000000000000000).should eql(OraNumber(-99999999999999999998))
   end
 
-  it "* Bignum should be an OraNumber" do
+  it "* Integer should be an OraNumber" do
     (OraNumber(2) * 100000000000000000000).should eql(OraNumber(200000000000000000000))
   end
 
-  it "/ Bignum should be an OraNumber" do
+  it "/ Integer should be an OraNumber" do
     (OraNumber(2) / 100000000000000000000).should eql(OraNumber("0.00000000000000000002"))
   end
 
@@ -124,7 +124,7 @@ describe OraNumber do
   end
 end
 
-describe Fixnum do
+describe Integer do # Ruby 2.3 or lower it was Fixnum
   it "+ OraNumber should be an OraNumber" do
     (2 + OraNumber(1)).should eql(OraNumber(3))
   end
@@ -142,7 +142,7 @@ describe Fixnum do
   end
 end
 
-describe Bignum do
+describe Integer do # Ruby 2.3 or lower it was Bignum
   it "+ OraNumber should be an OraNumber" do
     (100000000000000000000 + OraNumber(1)).should eql(OraNumber(100000000000000000001))
   end

--- a/test/test_array_dml.rb
+++ b/test/test_array_dml.rb
@@ -37,10 +37,10 @@ EOS
     
     cursor.bind_param_array(1, nil, String)
     cursor.bind_param_array(2, nil ,String)
-    cursor.bind_param_array(3, nil, Fixnum)
+    cursor.bind_param_array(3, nil, Integer)
     cursor.bind_param_array(4, nil, OraDate)
     cursor.bind_param_array(5, nil, Integer)
-    cursor.bind_param_array(6, nil, Bignum)
+    cursor.bind_param_array(6, nil, Integer)
     cursor.bind_param_array(7, nil, DateTime)
 
     c_arr = Array.new
@@ -91,7 +91,7 @@ EOS
     
     cursor = @conn.parse("SELECT * FROM test_table ORDER BY c")
     cursor.define(5, Integer)
-    cursor.define(6, Bignum)
+    cursor.define(6, Integer)
     cursor.exec
     assert_equal(["C","V","N","D","INT","BIGNUM","T"], cursor.get_col_names)
     1.upto(30) do |i|
@@ -121,7 +121,7 @@ EOS
     cursor = @conn.parse("INSERT INTO test_table VALUES (:N, :V)")
     max_array_size = 10
     cursor.max_array_size = max_array_size
-    cursor.bind_param_array(1, nil, Fixnum)
+    cursor.bind_param_array(1, nil, Integer)
     cursor.bind_param_array(2, nil, String)
     n_arr = Array.new
     v_arr = Array.new
@@ -173,7 +173,7 @@ EOS
     cursor = @conn.parse("INSERT INTO test_table VALUES (:N, :V)")
     max_array_size = 4
     cursor.max_array_size = max_array_size
-    cursor.bind_param_array(1, nil, Fixnum)
+    cursor.bind_param_array(1, nil, Integer)
     cursor.bind_param_array(2, nil, String)
     n_arr = Array.new
     v_arr = Array.new
@@ -210,7 +210,7 @@ EOS
     cursor = @conn.parse("INSERT INTO test_table VALUES (:N, :V)")
     max_array_size = 3
     cursor.max_array_size = max_array_size
-    cursor.bind_param_array(1, nil, Fixnum)
+    cursor.bind_param_array(1, nil, Integer)
     cursor.bind_param_array(2, nil, String)
     assert_raises(RuntimeError) { cursor.exec_array }
     cursor.close
@@ -235,7 +235,7 @@ EOS
       n_arr << i
       v_arr << i.to_s
     end    
-    cursor.bind_param_array(1, nil, Fixnum)
+    cursor.bind_param_array(1, nil, Integer)
     cursor.bind_param_array(2, nil, String)
     cursor[1] = n_arr
     cursor[2] = v_arr
@@ -250,7 +250,7 @@ EOS
         delete_arr << i
       end  
     end
-    cursor.bind_param_array(1, nil, Fixnum)
+    cursor.bind_param_array(1, nil, Integer)
     cursor[1] = delete_arr
     cursor.exec_array
     cursor.close
@@ -288,7 +288,7 @@ EOS
       n_arr << i
       v_arr << i.to_s
     end    
-    cursor.bind_param_array(1, nil, Fixnum)
+    cursor.bind_param_array(1, nil, Integer)
     cursor.bind_param_array(2, nil, String)
     cursor[1] = n_arr
     cursor[2] = v_arr
@@ -306,7 +306,7 @@ EOS
       end  
     end
     cursor.bind_param_array(1, nil, String)
-    cursor.bind_param_array(2, nil, Fixnum)
+    cursor.bind_param_array(2, nil, Integer)
     cursor[1] = update_v_arr
     cursor[2] = update_arr
     cursor.exec_array

--- a/test/test_bind_array.rb
+++ b/test/test_bind_array.rb
@@ -19,8 +19,8 @@ class TestBindArray < Minitest::Test
 
   def test_bind_array_values_containg_nil
     assert_equal([[nil, String]], OCI8::in_cond(:id, [nil]).values)
-    assert_equal([[nil, Fixnum], [2, nil, nil], [3, nil, nil]], OCI8::in_cond(:id, [nil, 2, 3]).values)
-    assert_equal([[1, nil, nil], [nil, Fixnum], [3, nil, nil]], OCI8::in_cond(:id, [1, nil, 3]).values)
+    assert_equal([[nil, 0.class], [2, nil, nil], [3, nil, nil]], OCI8::in_cond(:id, [nil, 2, 3]).values)
+    assert_equal([[1, nil, nil], [nil, 0.class], [3, nil, nil]], OCI8::in_cond(:id, [1, nil, 3]).values)
   end
 
   def test_bind_array_values_with_type

--- a/test/test_bind_time.rb
+++ b/test/test_bind_time.rb
@@ -17,7 +17,7 @@ class TestBindTime < Minitest::Test
   def test_set_year
     cursor = @conn.parse("BEGIN :year := TO_NUMBER(TO_CHAR(:time, 'SYYYY'), '9999'); END;")
     cursor.bind_param(:time, Time)
-    cursor.bind_param(:year, Fixnum)
+    cursor.bind_param(:year, Integer)
 
     YEAR_CHECK_TARGET.each do |i|
       # set year
@@ -30,7 +30,7 @@ class TestBindTime < Minitest::Test
 
   def test_get_year
     cursor = @conn.parse("BEGIN :time := TO_DATE(TO_CHAR(:year, '0999'), 'SYYYY'); END;")
-    cursor.bind_param(:year, Fixnum)
+    cursor.bind_param(:year, Integer)
     cursor.bind_param(:time, Time)
     YEAR_CHECK_TARGET.each do |i|
       # set time via oracle.
@@ -44,7 +44,7 @@ class TestBindTime < Minitest::Test
   def test_set_mon
     cursor = @conn.parse("BEGIN :mon := TO_NUMBER(TO_CHAR(:time, 'MM'), '99'); END;")
     cursor.bind_param(:time, Time)
-    cursor.bind_param(:mon, Fixnum)
+    cursor.bind_param(:mon, Integer)
     MON_CHECK_TARGET.each do |i|
       # set mon
       cursor[:time] = Time.local(2001, i)
@@ -56,7 +56,7 @@ class TestBindTime < Minitest::Test
 
   def test_get_mon
     cursor = @conn.parse("BEGIN :time := TO_DATE(TO_CHAR(:mon, '99'), 'MM'); END;")
-    cursor.bind_param(:mon, Fixnum)
+    cursor.bind_param(:mon, Integer)
     cursor.bind_param(:time, Time)
     MON_CHECK_TARGET.each do |i|
       # set time via oracle.
@@ -70,7 +70,7 @@ class TestBindTime < Minitest::Test
   def test_set_day
     cursor = @conn.parse("BEGIN :day := TO_NUMBER(TO_CHAR(:time, 'DD'), '99'); END;")
     cursor.bind_param(:time, Time)
-    cursor.bind_param(:day, Fixnum)
+    cursor.bind_param(:day, Integer)
     DAY_CHECK_TARGET.each do |i|
       # set day
       cursor[:time] = Time.local(2001, 1, i)
@@ -82,7 +82,7 @@ class TestBindTime < Minitest::Test
 
   def test_get_day
     cursor = @conn.parse("BEGIN :time := TO_DATE('200101' || TO_CHAR(:day, 'FM00'), 'YYYYMMDD'); END;")
-    cursor.bind_param(:day, Fixnum)
+    cursor.bind_param(:day, Integer)
     cursor.bind_param(:time, Time)
     DAY_CHECK_TARGET.each do |i|
       # set time via oracle.
@@ -96,7 +96,7 @@ class TestBindTime < Minitest::Test
   def test_set_hour
     cursor = @conn.parse("BEGIN :hour := TO_NUMBER(TO_CHAR(:time, 'HH24'), '99'); END;")
     cursor.bind_param(:time, Time)
-    cursor.bind_param(:hour, Fixnum)
+    cursor.bind_param(:hour, Integer)
     HOUR_CHECK_TARGET.each do |i|
       # set hour
       cursor[:time] = Time.local(2001, 1, 1, i)
@@ -108,7 +108,7 @@ class TestBindTime < Minitest::Test
 
   def test_get_hour
     cursor = @conn.parse("BEGIN :time := TO_DATE(TO_CHAR(:hour, '99'), 'HH24'); END;")
-    cursor.bind_param(:hour, Fixnum)
+    cursor.bind_param(:hour, Integer)
     cursor.bind_param(:time, Time)
     HOUR_CHECK_TARGET.each do |i|
       # set time via oracle.
@@ -122,7 +122,7 @@ class TestBindTime < Minitest::Test
   def test_set_min
     cursor = @conn.parse("BEGIN :min := TO_NUMBER(TO_CHAR(:time, 'MI'), '99'); END;")
     cursor.bind_param(:time, Time)
-    cursor.bind_param(:min, Fixnum)
+    cursor.bind_param(:min, Integer)
     MIN_CHECK_TARGET.each do |i|
       # set min
       cursor[:time] = Time.local(2001, 1, 1, 0, i)
@@ -134,7 +134,7 @@ class TestBindTime < Minitest::Test
 
   def test_get_min
     cursor = @conn.parse("BEGIN :time := TO_DATE(TO_CHAR(:min, '99'), 'MI'); END;")
-    cursor.bind_param(:min, Fixnum)
+    cursor.bind_param(:min, Integer)
     cursor.bind_param(:time, Time)
     MIN_CHECK_TARGET.each do |i|
       # set time via oracle.
@@ -148,7 +148,7 @@ class TestBindTime < Minitest::Test
   def test_set_sec
     cursor = @conn.parse("BEGIN :sec := TO_NUMBER(TO_CHAR(:time, 'SS'), '99'); END;")
     cursor.bind_param(:time, Time)
-    cursor.bind_param(:sec, Fixnum)
+    cursor.bind_param(:sec, Integer)
     SEC_CHECK_TARGET.each do |i|
       # set sec
       cursor[:time] = Time.local(2001, 1, 1, 0, 0, i)
@@ -160,7 +160,7 @@ class TestBindTime < Minitest::Test
 
   def test_get_sec
     cursor = @conn.parse("BEGIN :time := TO_DATE(TO_CHAR(:sec, '99'), 'SS'); END;")
-    cursor.bind_param(:sec, Fixnum)
+    cursor.bind_param(:sec, Integer)
     cursor.bind_param(:time, Time)
     SEC_CHECK_TARGET.each do |i|
       # set time via oracle.

--- a/test/test_dbi.rb
+++ b/test/test_dbi.rb
@@ -130,7 +130,7 @@ EOS
     sth.func(:define, 6, Date) # define 6th column as Date
     sth.func(:define, 7, DateTime) # define 7th column as DateTime
     sth.func(:define, 8, Integer) # define 8th column as Integer
-    sth.func(:define, 9, Bignum) # define 9th column as Bignum
+    sth.func(:define, 9, Integer) # define 9th column as Integer
     sth.execute
     assert_equal(["C", "V", "N", "D1", "D2", "D3", "D4", "INT", "BIGNUM"], sth.column_info.collect {|cl| cl.name})
     1.upto(10) do |i|

--- a/test/test_oci8.rb
+++ b/test/test_oci8.rb
@@ -107,7 +107,7 @@ EOS
     cursor.define(6, Date) # define 6th column as Date
     cursor.define(7, DateTime) # define 7th column as DateTime
     cursor.define(8, Integer) # define 8th column as Integer
-    cursor.define(9, Bignum) # define 9th column as Bignum
+    cursor.define(9, Integer) # define 9th column as Integer
     cursor.exec
     assert_equal(["C", "V", "N", "D1", "D2", "D3", "D4", "INT", "BIGNUM"], cursor.get_col_names)
     1.upto(10) do |i|
@@ -204,7 +204,7 @@ EOS
     cursor.define(5, DateTime) # define 5th column as DateTime
     cursor.define(6, Date) # define 6th column as Date
     cursor.define(7, Integer) # define 7th column as Integer
-    cursor.define(8, Bignum) # define 8th column as Integer
+    cursor.define(8, Integer) # define 8th column as Integer
     assert_equal(["C", "V", "N", "D1", "D2", "D3", "INT", "BIGNUM"], cursor.get_col_names)
     1.upto(10) do |i|
       rv = cursor.fetch
@@ -370,7 +370,7 @@ EOS
       assert_equal(row[3], BigDecimal("1234567890123.45"))
       assert_equal(row[4], 1234.5)
       assert_instance_of(BigDecimal, row[0])
-      assert_instance_of(Bignum, row[1])
+      assert_instance_of((2**64).class, row[1])
       assert_instance_of(Float, row[2])
       assert_instance_of(BigDecimal, row[3])
       assert_instance_of(Float, row[4])
@@ -397,14 +397,14 @@ EOS
       assert_kind_of(Float, cursor[1])
     end
 
-    # Fixnum
-    cursor.bind_param(1, nil, Fixnum)
-    cursor.bind_param(2, nil, Fixnum)
+    # Integer
+    cursor.bind_param(1, nil, Integer)
+    cursor.bind_param(2, nil, Integer)
     src.each_with_index do |s, idx|
       cursor[2] = s
       cursor.exec
       assert_equal(cursor[1], int[idx])
-      assert_kind_of(Fixnum, cursor[1])
+      assert_kind_of(Integer, cursor[1])
     end
 
     # Integer

--- a/test/test_oradate.rb
+++ b/test/test_oradate.rb
@@ -31,7 +31,7 @@ class TestOraDate < Minitest::Test
   def test_set_year
     cursor = @conn.parse("BEGIN :year := TO_NUMBER(TO_CHAR(:date, 'SYYYY'), '9999'); END;")
     cursor.bind_param(:date, OraDate)
-    cursor.bind_param(:year, Fixnum)
+    cursor.bind_param(:year, Integer)
     date = OraDate.new()
     YEAR_CHECK_TARGET.each do |i|
       # set year
@@ -45,7 +45,7 @@ class TestOraDate < Minitest::Test
 
   def test_get_year
     cursor = @conn.parse("BEGIN :date := TO_DATE(TO_CHAR(:year, '0999'), 'SYYYY'); END;")
-    cursor.bind_param(:year, Fixnum)
+    cursor.bind_param(:year, Integer)
     cursor.bind_param(:date, OraDate)
     YEAR_CHECK_TARGET.each do |i|
       # set date via oracle.
@@ -59,7 +59,7 @@ class TestOraDate < Minitest::Test
   def test_set_month
     cursor = @conn.parse("BEGIN :month := TO_NUMBER(TO_CHAR(:date, 'MM'), '99'); END;")
     cursor.bind_param(:date, OraDate)
-    cursor.bind_param(:month, Fixnum)
+    cursor.bind_param(:month, Integer)
     date = OraDate.new()
     MONTH_CHECK_TARGET.each do |i|
       # set month
@@ -73,7 +73,7 @@ class TestOraDate < Minitest::Test
 
   def test_get_month
     cursor = @conn.parse("BEGIN :date := TO_DATE(TO_CHAR(:month, '99'), 'MM'); END;")
-    cursor.bind_param(:month, Fixnum)
+    cursor.bind_param(:month, Integer)
     cursor.bind_param(:date, OraDate)
     MONTH_CHECK_TARGET.each do |i|
       # set date via oracle.
@@ -87,7 +87,7 @@ class TestOraDate < Minitest::Test
   def test_set_day
     cursor = @conn.parse("BEGIN :day := TO_NUMBER(TO_CHAR(:date, 'DD'), '99'); END;")
     cursor.bind_param(:date, OraDate)
-    cursor.bind_param(:day, Fixnum)
+    cursor.bind_param(:day, Integer)
     date = OraDate.new()
     DAY_CHECK_TARGET.each do |i|
       # set day
@@ -101,7 +101,7 @@ class TestOraDate < Minitest::Test
 
   def test_get_day
     cursor = @conn.parse("BEGIN :date := TO_DATE('200101' || TO_CHAR(:day, 'FM00'), 'YYYYMMDD'); END;")
-    cursor.bind_param(:day, Fixnum)
+    cursor.bind_param(:day, Integer)
     cursor.bind_param(:date, OraDate)
     DAY_CHECK_TARGET.each do |i|
       # set date via oracle.
@@ -115,7 +115,7 @@ class TestOraDate < Minitest::Test
   def test_set_hour
     cursor = @conn.parse("BEGIN :hour := TO_NUMBER(TO_CHAR(:date, 'HH24'), '99'); END;")
     cursor.bind_param(:date, OraDate)
-    cursor.bind_param(:hour, Fixnum)
+    cursor.bind_param(:hour, Integer)
     date = OraDate.new()
     HOUR_CHECK_TARGET.each do |i|
       # set hour
@@ -129,7 +129,7 @@ class TestOraDate < Minitest::Test
 
   def test_get_hour
     cursor = @conn.parse("BEGIN :date := TO_DATE(TO_CHAR(:hour, '99'), 'HH24'); END;")
-    cursor.bind_param(:hour, Fixnum)
+    cursor.bind_param(:hour, Integer)
     cursor.bind_param(:date, OraDate)
     HOUR_CHECK_TARGET.each do |i|
       # set date via oracle.
@@ -143,7 +143,7 @@ class TestOraDate < Minitest::Test
   def test_set_minute
     cursor = @conn.parse("BEGIN :minute := TO_NUMBER(TO_CHAR(:date, 'MI'), '99'); END;")
     cursor.bind_param(:date, OraDate)
-    cursor.bind_param(:minute, Fixnum)
+    cursor.bind_param(:minute, Integer)
     date = OraDate.new()
     MINUTE_CHECK_TARGET.each do |i|
       # set minute
@@ -157,7 +157,7 @@ class TestOraDate < Minitest::Test
 
   def test_get_minute
     cursor = @conn.parse("BEGIN :date := TO_DATE(TO_CHAR(:minute, '99'), 'MI'); END;")
-    cursor.bind_param(:minute, Fixnum)
+    cursor.bind_param(:minute, Integer)
     cursor.bind_param(:date, OraDate)
     MINUTE_CHECK_TARGET.each do |i|
       # set date via oracle.
@@ -171,7 +171,7 @@ class TestOraDate < Minitest::Test
   def test_set_second
     cursor = @conn.parse("BEGIN :second := TO_NUMBER(TO_CHAR(:date, 'SS'), '99'); END;")
     cursor.bind_param(:date, OraDate)
-    cursor.bind_param(:second, Fixnum)
+    cursor.bind_param(:second, Integer)
     date = OraDate.new()
     SECOND_CHECK_TARGET.each do |i|
       # set second
@@ -185,7 +185,7 @@ class TestOraDate < Minitest::Test
 
   def test_get_second
     cursor = @conn.parse("BEGIN :date := TO_DATE(TO_CHAR(:second, '99'), 'SS'); END;")
-    cursor.bind_param(:second, Fixnum)
+    cursor.bind_param(:second, Integer)
     cursor.bind_param(:date, OraDate)
     SECOND_CHECK_TARGET.each do |i|
       # set date via oracle.


### PR DESCRIPTION
## Summary

Ruby 2.4.0 unifies Fixnum and Bignum into Integer.

https://bugs.ruby-lang.org/issues/12005

Fix following deprecated warnings in Ruby 2.4.0+.

- `warning: constant ::Fixnum is deprecated`
- `warning: constant ::Bignum is deprecated`

There are notes below. The following codes are for compatibility with 2.3 or lower.

### 0.class

```ruby
# Ruby 2.3 or lower
0.class       #=> Fixnum
# Ruby 2.4 or higher
0.class       #=> Integer
```

### (2**64).class

```ruby
# Ruby 2.3 or lower
(2**64).class #=> Bignum
# Ruby 2.4 or higher
(2**64).class #=> Integer
```

I wrote assuming that `(2**64)` is big enough become `Bignum`.

And, it is unified with `Integer` for codes without problem.

## oracle-enhanced

This PR is also confirmed by the following combinations.

- oracle-enhanced (1.7.8) and MRI (2.4.0-rc1)
- oracle-enhanced (1.7.8) and MRI (2.3.3)

Thanks.
