### PR TITLE
Fix date/time test (expected time timezone)

### DIFF
--- a/test/test_oci8.rb
+++ b/test/test_oci8.rb
@@ -216,8 +216,8 @@ EOS
 	assert_nil(rv[4])
 	assert_nil(rv[5])
       else
-	dttm = DateTime.civil(2000 + i, 8, 3, 23, 59, 59, Time.now.utc_offset.to_r/86400)
         tm = Time.local(2000 + i, 8, 3, 23, 59, 59)
+        dttm = DateTime.civil(2000 + i, 8, 3, 23, 59, 59, tm.utc_offset.to_r/86400)
 	dt = Date.civil(2000 + i, 8, 3)
 	assert_equal(tm, rv[3])
 	assert_equal(dttm, rv[4])


### PR DESCRIPTION
`Time.now` offset leads to unstable test due to DST sensitivity (e.g. the test is broken if executed in winter for `Europe/Helsinki` time zone). The solution is to take the offset of the specific local date/time.