### PR TITLE
Tests for binding integer cursor in parameters

### DIFF
--- a/dist-files
+++ b/dist-files
@@ -86,6 +86,7 @@ test/test_array_dml.rb
 test/test_bind_raw.rb
 test/test_bind_string.rb
 test/test_bind_time.rb
+test/test_bind_integer.rb
 test/test_break.rb
 test/test_clob.rb
 test/test_connection_pool.rb

--- a/lib/oci8/cursor.rb
+++ b/lib/oci8/cursor.rb
@@ -58,15 +58,16 @@ class OCI8
     #   # ...or...
     #   cursor.bind_param(':ename', 'SMITH') # bind by name
     #
-    # To bind as number, Fixnum and Float are available, but Bignum is
-    # not supported. If its initial value is NULL, please set nil to 
-    # +type+ and Fixnum or Float to +val+.
+    # To bind as number, set the number intself to +val+. If its initial value
+    # is NULL, please set nil to +type+ and Integer, Float or OraNumber to +val+.
     #
     # example:
-    #   cursor.bind_param(1, 1234) # bind as Fixnum, Initial value is 1234.
+    #   cursor.bind_param(1, 1234) # bind as Integer, Initial value is 1234.
     #   cursor.bind_param(1, 1234.0) # bind as Float, Initial value is 1234.0.
-    #   cursor.bind_param(1, nil, Fixnum) # bind as Fixnum, Initial value is NULL.
+    #   cursor.bind_param(1, nil, Integer) # bind as Integer, Initial value is NULL.
     #   cursor.bind_param(1, nil, Float) # bind as Float, Initial value is NULL.
+    #   cursor.bind_param(1, OraNumber(1234)) # bind as OraNumber, Initial value is 1234.
+    #   cursor.bind_param(1, nil, OraNumber) # bind as OraNumber, Initial value is NULL.
     #
     # In case of binding a string, set the string itself to
     # +val+. When the bind variable is used as output, set the

--- a/test/test_all.rb
+++ b/test/test_all.rb
@@ -9,6 +9,7 @@ require "#{srcdir}/test_bind_array.rb"
 require "#{srcdir}/test_bind_string"
 require "#{srcdir}/test_bind_time"
 require "#{srcdir}/test_bind_raw"
+require "#{srcdir}/test_bind_integer"
 if $test_clob
   require "#{srcdir}/test_clob"
 end

--- a/test/test_bind_integer.rb
+++ b/test/test_bind_integer.rb
@@ -1,0 +1,47 @@
+require 'oci8'
+require File.dirname(__FILE__) + '/config'
+
+class TestBindInteger < Minitest::Test
+
+  def setup
+    @conn = get_oci8_connection
+  end
+
+  POSITIVE_INTS = [
+    100,
+    2**30,
+    2**31,
+    2**32,
+    2**33,
+    2**62,
+    2**63,
+    2**64,
+    ('9' * 38).to_i
+  ]
+
+  def bind_and_get(input_value, output_type)
+    cursor = @conn.parse("BEGIN :out := :in; END;")
+    cursor.bind_param(:out, output_type)
+    cursor.bind_param(:in, input_value)
+    cursor.exec
+    result = cursor[:out]
+    cursor.close
+    result
+  end
+
+  (POSITIVE_INTS + [0] + POSITIVE_INTS.map(&:-@)).each do |num|
+    define_method("test_bind_param_with_input_of '#{num}'") do
+      assert_equal(OraNumber.new(num.to_s), bind_and_get(num, OraNumber))
+    end
+
+    define_method("test_bind_param_with_output_of '#{num}'") do
+      result = bind_and_get(OraNumber.new(num.to_s), Integer)
+      assert_equal(num, result)
+      assert_kind_of(Integer, result)
+    end
+  end
+
+  def teardown
+    @conn.logoff
+  end
+end


### PR DESCRIPTION
Add tests for binding a range of small and large integer variables directly (not through `OraNumber`).

I have only ran the tests with Ruby `2.4.0`, `2.3.3` and Oracle 11.2 (tests passed). If the added tests are correct for any versions supported - perhaps it makes sense to also remove the comment at [cursor.rb#L61-L62](https://github.com/kubo/ruby-oci8/blob/a9ac6bbd34b91795e8deba81d77223bfdb4abb64/lib/oci8/cursor.rb#L61-L62) as it leads to implementations with separate branches for `Fixnum` and `Bignum`.