### PR TITLE
Removed too specific version constraint

### DIFF
--- a/ruby-oci8.gemspec
+++ b/ruby-oci8.gemspec
@@ -64,11 +64,7 @@ EOS
       raise "No compiled binary are found. Run make in advance."
     when 1
       puts "Binary gem for ruby #{so_vers.first}"
-      if so_vers[0] < '2.0.0'
-        s.required_ruby_version = "~> #{so_vermin}"
-      else
-        s.required_ruby_version = "~> #{so_vermin}.0"
-      end
+      s.required_ruby_version = "~> #{so_vermin}"
     else
       puts "Binary gem for ruby #{so_vers.join(', ')}"
       s.required_ruby_version = ">= #{so_vermin}"


### PR DESCRIPTION
Fixes bug #155, tested using test release:
https://github.com/greenfieldtech-davidb/ruby-oci8/releases/tag/ruby-oci8-2.2.3.1