### PR TITLE
Do not call __paramGet(i) when @define_handles[i - 1] is already defined

### DIFF
--- a/lib/oci8/cursor.rb
+++ b/lib/oci8/cursor.rb
@@ -516,14 +516,13 @@ class OCI8
       # http://docs.oracle.com/cd/E11882_01/appdev.112/e10646/ociaahan.htm#sthref5494
       num_cols = attr_get_ub4(18) # OCI_ATTR_PARAM_COUNT(18)
       1.upto(num_cols) do |i|
-        parm = __paramGet(i)
-        define_one_column(i, parm) unless @define_handles[i - 1]
-        @column_metadata[i - 1] = parm
+        define_one_column(i) unless @define_handles[i - 1]
       end
       num_cols
     end
 
-    def define_one_column(pos, param)
+    def define_one_column(pos)
+      param = @column_metadata[pos - 1] = __paramGet(pos)
       bindobj = make_bind_object(param)
       __define(pos, bindobj)
       if old = @define_handles[pos - 1]


### PR DESCRIPTION
Hello.

It looks needless to me that `__paramGet(i)` is called for every call of `exec` (via `define_columns`).

BTW, I am using ruby-oci8 with activerecord-oracle_enhanced-adapter.
When one query is executed repeatedly with different bind parameters, 
activerecord-oracle_enhanced-adapter keeps one cursor for the query and call `exec` (and `__paramsGet`) of the cursor.
I encoutered a problem that `__paramsGet` becomes very slow as it is called. 
I hope that this pull request fixes the problem.