### PR TITLE
Suppress `warning: BigDecimal.new is deprecated`

### DIFF
--- a/test/test_oranumber.rb
+++ b/test/test_oranumber.rb
@@ -702,12 +702,12 @@ EOS
   def test_new_from_bigdecimal
     ["+Infinity", "-Infinity", "NaN"].each do |n|
       assert_raises TypeError do
-        OraNumber.new(BigDecimal.new(n))
+        OraNumber.new(BigDecimal(n))
       end
     end
 
     LARGE_RANGE_VALUES.each do |val|
-      assert_equal(val, OraNumber.new(BigDecimal.new(val)).to_s)
+      assert_equal(val, OraNumber.new(BigDecimal(val)).to_s)
     end
   end
 


### PR DESCRIPTION
BigDecimal.new is deprecated in Ruby 2.5.
https://github.com/ruby/bigdecimal/commit/5337373

* Steps to reproduce:

```ruby
$ ruby -v
ruby 2.5.0rc1 (2017-12-14 trunk 61243) [x86_64-linux]
$ make check

... snip ...

/path/to/ruby-oci8/test/test_oranumber.rb:705: warning: BigDecimal.new is deprecated
/path/to/ruby-oci8/test/test_oranumber.rb:710: warning: BigDecimal.new is deprecated

... snip ...
```

* This pull request has been tested with these versions of Ruby:
```
ruby 2.5.0dev (2017-12-21 trunk 61391) [x86_64-linux]
ruby 2.4.3p205 (2017-12-14 revision 61247) [x86_64-linux]
ruby 2.3.6p384 (2017-12-14 revision 61254) [x86_64-linux]
ruby 2.2.9p480 (2017-12-15 revision 61259) [x86_64-linux]
ruby 2.1.9p490 (2016-03-30 revision 54437) [x86_64-linux]
ruby 2.0.0p648 (2015-12-16 revision 53162) [x86_64-linux]
```