### PR TITLE
Suppress expected exceptions tested with Ruby 2.5

### DIFF
--- a/test/test_break.rb
+++ b/test/test_break.rb
@@ -7,10 +7,12 @@ class TestBreak < Minitest::Test
 
   def setup
     @conn = get_oci8_connection
+    Thread.report_on_exception, @original_report_on_exception = false, Thread.report_on_exception if Thread.respond_to?(:report_on_exception)
   end
 
   def teardown
     @conn.logoff
+    Thread.report_on_exception = @original_report_on_exception if Thread.respond_to?(:report_on_exception)
   end
 
   def report(str)


### PR DESCRIPTION
```ruby
$ make check
... snip ...

Traceback (most recent call last):
        3: from /home/yahonda/git/ruby-oci8/test/test_break.rb:42:in `block in do_test_ocibreak'
        2: from /home/yahonda/git/ruby-oci8/test/test_break.rb:46:in `rescue in block in do_test_ocibreak'
        1: from /home/yahonda/.rbenv/versions/2.5.0-rc1/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest/assertions.rb:174:in `assert_equal'
/home/yahonda/.rbenv/versions/2.5.0-rc1/lib/ruby/gems/2.5.0/gems/minitest-5.10.3/lib/minitest/assertions.rb:139:in `assert': OCIBREAK. (Minitest::Assertion)
... snip ...
```

* Ruby 2.4 introduces `report_on_exception` to control if it reports exceptions in thread,
this default value has been `false` in Ruby 2.4.

Refer https://www.ruby-lang.org/en/news/2016/11/09/ruby-2-4-0-preview3-released/

* Ruby 2.5 changes `report_on_exception` default value to `true`
since this commit https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=61183&view=revision

This pull request suppresses expected exceptions by setting `report_on_exception` = `false`
it also supports Ruby 2.3 which does not have`report_on_exception`.