### PR TITLE
CI with Ruby 2.5.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
   # Version of ruby to use
   ruby:
     version:
-      2.4.0
+      2.5.0
 
   # Add some environment variables
   environment:
@@ -23,8 +23,6 @@ machine:
 
 ## Customize dependencies
 dependencies:
-  pre:
-    - rvm install 2.4.0
   override:
     - cisetup/oracle/download.sh
     - cisetup/oracle/install.sh


### PR DESCRIPTION
"Ruby 2.5.0 Released"
https://www.ruby-lang.org/en/news/2017/12/25/ruby-2-5-0-released/

No need to run `rvm install 2.5.0` in the dependency tag.