### PR TITLE
Configure Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+dist: trusty
+sudo: required
+cache: bundler
+
+env:
+  global:
+    - ORACLE_FILE=oracle11g/xe/oracle-xe-11.2.0-1.0.x86_64.rpm.zip
+    - ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe
+    - TNS_ADMIN=$ORACLE_HOME/network/admin
+    - NLS_LANG=AMERICAN_AMERICA.AL32UTF8
+    - ORACLE_BASE=/u01/app/oracle
+    - LD_LIBRARY_PATH=$ORACLE_HOME/lib
+    - PATH=$PATH:$ORACLE_HOME/jdbc/lib
+    - DATABASE_VERSION=11.2.0.1
+    - ORACLE_SID=XE
+    - DATABASE_NAME=XE
+    - ORA_SDTZ='Europe/Riga' #Needed as a client parameter
+    - TZ='Europe/Riga'       #Needed as a DB Server parameter
+
+before_install:
+  - chmod +x cisetup/oracle/download.sh
+  - chmod +x cisetup/oracle/install.sh
+  - chmod +x cisetup/setup_accounts.sh
+
+install:
+ - cisetup/oracle/download.sh
+ - cisetup/oracle/install.sh
+ - cisetup/setup_accounts.sh
+
+script:
+  - make check
+
+language: ruby
+rvm:
+  - 2.5.1
+
+notifications:
+    email: false


### PR DESCRIPTION
Since CircleCI 1.0 is shutting down on Aug 31th, 2018.
https://circleci.com/blog/sunsetting-1-0/

Rather than migrating from CircleCI 1.0 to 2.0, I prefer to running Travis CI.