### PR TITLE
Suppress `NOTE: Gem::Specification#has_rdoc= is deprecated`

### DIFF
--- a/ruby-oci8.gemspec
+++ b/ruby-oci8.gemspec
@@ -34,7 +34,6 @@ spec = Gem::Specification.new do |s|
   s.description = <<EOS
 ruby-oci8 is a ruby interface for Oracle using OCI8 API. It is available with Oracle 10g or later including Oracle Instant Client.
 EOS
-  s.has_rdoc = 'yard'
   s.authors = ['Kubo Takehiro']
   s.platform = gem_platform
   s.license = 'BSD-2-Clause'


### PR DESCRIPTION
This pull request suppresses the following deprecation message introduced at RubyGems 1.7.0 https://blog.rubygems.org/2011/03/28/1.7.0-released.html 

```ruby
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /home/yahonda/.rbenv/versions/2.6.0-preview3/lib/ruby/gems/2.6.0/bundler/gems/ruby-oci8-2c5d364c3f32/ruby-oci8.gemspec:37.
```

### Steps to reproduce:

```ruby
$ ruby -v
ruby 2.6.0preview3 (2018-11-06 trunk 65578) [x86_64-linux]
$ gem -v
3.0.0.beta2
$ git clone https://github.com/rsim/oracle-enhanced.git
$ cd oracle-enhanced
$ bundle
Fetching https://github.com/rails/rails.git
Fetching https://github.com/rsim/ruby-plsql.git
Fetching https://github.com/kubo/ruby-oci8.git
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /home/yahonda/.rbenv/versions/2.6.0-preview3/lib/ruby/gems/2.6.0/bundler/gems/ruby-oci8-2c5d364c3f32/ruby-oci8.gemspec:37.
```