### PR TITLE
(Nix) Allow for specifying include/library paths

### DIFF
--- a/ext/oci8/oraconf.rb
+++ b/ext/oci8/oraconf.rb
@@ -266,8 +266,12 @@ EOS
         OraConfIC.new(inc, lib)
       else
 	base = guess_ic_dir
-        inc, lib = guess_dirs_from_ic_base(base)
-        OraConfIC.new(inc, lib)
+	if base
+          inc, lib = guess_dirs_from_ic_base(base)
+          OraConfIC.new(inc, lib)
+	else
+	  OraConfFC.new
+	end
       end
     rescue
       case ENV['LANG']

--- a/ext/oci8/oraconf.rb
+++ b/ext/oci8/oraconf.rb
@@ -250,7 +250,6 @@ class OraConf
   def self.get
     original_CFLAGS = $CFLAGS
     original_defs = $defs
-    ic_dir = nil
     begin
       # check Oracle instant client
       if with_config('instant-client')
@@ -267,7 +266,7 @@ EOS
         OraConfIC.new(inc, lib)
       else
 	base = guess_ic_dir
-        inc, lib = guess_dirs_from_ic_base(ic_dir)
+        inc, lib = guess_dirs_from_ic_base(base)
         OraConfIC.new(inc, lib)
       end
     rescue

--- a/ext/oci8/oraconf.rb
+++ b/ext/oci8/oraconf.rb
@@ -262,11 +262,13 @@ class OraConf
 =======================================================
 EOS
       end
-      ic_dir = check_ic_dir
-      if ic_dir
-        OraConfIC.new(ic_dir)
+      inc, lib = dir_config('instant-client')
+      if inc && lib
+        OraConfIC.new(inc, lib)
       else
-        OraConfFC.new()
+	base = guess_ic_dir
+        inc, lib = guess_dirs_from_ic_base(ic_dir)
+        OraConfIC.new(inc, lib)
       end
     rescue
       case ENV['LANG']
@@ -298,6 +300,44 @@ EOS
     end
   end
 
+  # Guess the include and directory paths from 
+  def self.guess_dirs_from_ic_base(ic_dir)
+    if ic_dir =~ /^\/usr\/lib(?:64)?\/oracle\/(\d+(?:\.\d+)*)\/client(64)?\/lib(?:64)?/
+      # rpm package
+      #   x86 rpms after 11.1.0.7.0:
+      #    library: /usr/lib/oracle/X.X/client/lib/
+      #    include: /usr/include/oracle/X.X/client/
+      #
+      #   x86_64 rpms after 11.1.0.7.0:
+      #    library: /usr/lib/oracle/X.X/client64/lib/
+      #    include: /usr/include/oracle/X.X/client64/
+      #
+      #   x86 rpms before 11.1.0.6.0:
+      #    library: /usr/lib/oracle/X.X.X.X/client/lib/
+      #    include: /usr/include/oracle/X.X.X.X/client/
+      #
+      #   x86_64 rpms before 11.1.0.6.0:
+      #    library: /usr/lib/oracle/X.X.X.X/client64/lib/
+      #    include: /usr/include/oracle/X.X.X.X/client64/
+      #
+      #   third-party x86_64 rpms(*1):
+      #    library: /usr/lib64/oracle/X.X.X.X/client/lib/
+      #          or /usr/lib64/oracle/X.X.X.X/client/lib64/
+      #    include: /usr/include/oracle/X.X.X.X/client/
+      #
+      #   *1 These had been used before Oracle released official x86_64 rpms.
+      #
+      lib_dir = ic_dir
+      inc_dir = "/usr/include/oracle/#{$1}/client#{$2}"
+    else
+      # zip package
+      lib_dir = ic_dir
+      inc_dir = "#{ic_dir}/sdk/include"
+    end
+
+    [inc_dir, lib_dir]
+  end
+
   def self.ld_envs
     @@ld_envs
   end
@@ -316,8 +356,9 @@ EOS
     end
   end
 
-  def self.check_ic_dir
-    puts "checking for load library path... "
+  def self.guess_ic_dir
+    puts "attempting to locate oracle-instantclient..."
+    puts "checking load library path... "
     STDOUT.flush
 
     # get library load path names
@@ -947,41 +988,8 @@ end
 
 # OraConf for Instant Client
 class OraConfIC < OraConf
-  def initialize(ic_dir)
+  def initialize(inc_dir, lib_dir)
     init
-
-    if ic_dir =~ /^\/usr\/lib(?:64)?\/oracle\/(\d+(?:\.\d+)*)\/client(64)?\/lib(?:64)?/
-      # rpm package
-      #   x86 rpms after 11.1.0.7.0:
-      #    library: /usr/lib/oracle/X.X/client/lib/
-      #    include: /usr/include/oracle/X.X/client/
-      #
-      #   x86_64 rpms after 11.1.0.7.0:
-      #    library: /usr/lib/oracle/X.X/client64/lib/
-      #    include: /usr/include/oracle/X.X/client64/
-      #
-      #   x86 rpms before 11.1.0.6.0:
-      #    library: /usr/lib/oracle/X.X.X.X/client/lib/
-      #    include: /usr/include/oracle/X.X.X.X/client/
-      #
-      #   x86_64 rpms before 11.1.0.6.0:
-      #    library: /usr/lib/oracle/X.X.X.X/client64/lib/
-      #    include: /usr/include/oracle/X.X.X.X/client64/
-      #
-      #   third-party x86_64 rpms(*1):
-      #    library: /usr/lib64/oracle/X.X.X.X/client/lib/
-      #          or /usr/lib64/oracle/X.X.X.X/client/lib64/
-      #    include: /usr/include/oracle/X.X.X.X/client/
-      #
-      #   *1 These had been used before Oracle released official x86_64 rpms.
-      #
-      lib_dir = ic_dir
-      inc_dir = "/usr/include/oracle/#{$1}/client#{$2}"
-    else
-      # zip package
-      lib_dir = ic_dir
-      inc_dir = "#{ic_dir}/sdk/include"
-    end
 
     if RUBY_PLATFORM =~ /mswin32|mswin64|cygwin|mingw32|bccwin32/ # when Windows
       unless File.exist?("#{ic_dir}/sdk/lib/msvc/oci.lib")

--- a/setup.rb
+++ b/setup.rb
@@ -189,7 +189,16 @@ class ConfigTable
                      'the make program to compile ruby extentions' ] ],
     [ 'without-ext', [ 'no',
                        'yes/no',
-                       'does not compile/install ruby extentions' ] ]
+                       'does not compile/install ruby extentions' ] ],
+    [ 'with-instant-client-dir', ['',
+                                  'path',
+                                  'path to the Oracle instant client directory'] ],
+    [ 'with-instant-client-lib', ['',
+                                  'path',
+                                  'path to the Oracle instant client libraries'] ],
+    [ 'with-instant-client-include', ['',
+                                      'path',
+                                      'path to the Oracle instant client header files'] ]
   ]
   multipackage_descripters = [
     [ 'with',      [ '',


### PR DESCRIPTION
Currently this package is not buildable on Nix for a few reasons.

It uses a hardcoded `/sbin/ldconfig` reference, requires LD_LIBRARY_PATH hacks to introduce oracle-instantclient to the extconf.rb process, and the package further assumes some special directory structure (which the oracle-instantclient package from nixpkgs does not follow)..

Rather than try identifying nix and special casing the lib/include paths, it is easier if nix can control the lib/include paths itself.

This patch adds support for three flags. `--with-instant-client-dir`, `--with-instant-client-include` and `--with-instant-client-lib`. The behavior of the package is left unchanged if those flags are not specified.