### PR TITLE
Compilation fix for Windows ( and some small cleanups )

### DIFF
--- a/ext/oci8/bind.c
+++ b/ext/oci8/bind.c
@@ -383,7 +383,7 @@ static sb4 in_bind_callback(void *ictxp, OCIBind *bindp, ub4 iter, ub4 index, vo
 
     if (cb->tail == &cb->head) {
         /* empty string */
-        *bufpp = "";
+        *bufpp = (void *)"";
         *alenp = 0;
         *piecep = OCI_ONE_PIECE;
     } else {

--- a/ext/oci8/oci8.h
+++ b/ext/oci8/oci8.h
@@ -424,6 +424,7 @@ void *oci8_check_typeddata(VALUE obj, const oci8_handle_data_type_t *data_type, 
 extern VALUE eOCIException;
 extern VALUE eOCIBreak;
 void Init_oci8_error(void);
+NORETURN(void oci8_do_raise(OCIError *errhp, sword status, OCIStmt *stmthp, const char *file, int line));
 NORETURN(void oci8_do_env_raise(OCIEnv *envhp, sword status, int free_envhp, const char *file, int line));
 NORETURN(void oci8_do_raise_init_error(const char *file, int line));
 sb4 oci8_get_error_code(OCIError *errhp);

--- a/ext/oci8/oraconf.rb
+++ b/ext/oci8/oraconf.rb
@@ -995,16 +995,16 @@ class OraConfIC < OraConf
     init
 
     if RUBY_PLATFORM =~ /mswin32|mswin64|cygwin|mingw32|bccwin32/ # when Windows
-      unless File.exist?("#{ic_dir}/sdk/lib/msvc/oci.lib")
+      unless File.exist?("#{lib_dir}/sdk/lib/msvc/oci.lib")
         raise <<EOS
 Could not compile with Oracle instant client.
-#{ic_dir}/sdk/lib/msvc/oci.lib could not be found.
+#{lib_dir}/sdk/lib/msvc/oci.lib could not be found.
 EOS
         raise 'failed'
       end
       @cflags = " \"-I#{inc_dir}\""
       @cflags += " -D_int64=\"long long\"" if RUBY_PLATFORM =~ /cygwin|mingw32/
-      @libs = get_libs("#{ic_dir}/sdk/lib")
+      @libs = get_libs("#{lib_dir}/sdk/lib")
       ld_path = nil
     else
       @cflags = " -I#{inc_dir}"

--- a/lib/oci8.rb
+++ b/lib/oci8.rb
@@ -11,8 +11,11 @@ if RUBY_PLATFORM =~ /cygwin/
   # Cygwin manages environment variables by itself.
   # They don't synchroize with Win32's ones.
   # This set some Oracle's environment variables to win32's enviroment.
-  require 'Win32API'
-  win32setenv = Win32API.new('Kernel32.dll', 'SetEnvironmentVariableA', 'PP', 'I')
+  require 'fiddle'
+  win32setenv = Fiddle::Function.new( Fiddle.dlopen('Kernel32.dll')['SetEnvironmentVariableA'],
+                                        [Fiddle::TYPE_VOIDP,Fiddle::TYPE_VOIDP],
+                                        Fiddle::TYPE_INT )
+
   ['NLS_LANG', 'TNS_ADMIN', 'LOCAL'].each do |name|
     val = ENV[name]
     win32setenv.call(name, val && val.dup)

--- a/setup.rb
+++ b/setup.rb
@@ -286,7 +286,7 @@ class ConfigTable
 
   def initialize_from_table
     @table = {}
-    DESCRIPTER.each do |k, (default, vname, desc, default2)|
+    DESCRIPTER.each do |k, (default, *)|
       @table[k] = default
     end
   end


### PR DESCRIPTION
Hi, 
I was not able to compile the package on windows, there was a typo. Corrected in commit e56aca1

During the compilation there was some warnings. Corrected in commits 5caa3a0, 5aa6b66, d9980b2 

Using fiddler for Win32 calls instead Win32API package. (commit  b7beed1). 

README.md file update so that the links on github page will be correctly displayed. commit 803793b and 5810488