### PR TITLE
Straight mapping of OCI transaction functions to ruby-oci8

### DIFF
--- a/ext/oci8/apiwrap.yml
+++ b/ext/oci8/apiwrap.yml
@@ -868,6 +868,30 @@ OCITransCommit_nb:
             - ub4 flags
 
 # round trip: 1
+OCITransDetach_nb:
+  :version: 800
+  :args:
+            - OCISvcCtx *svchp
+            - OCIError *errhp
+            - ub4 flags
+
+# round trip: 1
+OCITransForget_nb:
+  :version: 800
+  :args:
+            - OCISvcCtx *svchp
+            - OCIError *errhp
+            - ub4 flags
+
+# round trip: 1
+OCITransPrepare_nb:
+  :version: 800
+  :args:
+            - OCISvcCtx *svchp
+            - OCIError *errhp
+            - ub4 flags
+
+# round trip: 1
 OCITransRollback:
   :version: 800
   :args:
@@ -881,6 +905,15 @@ OCITransRollback_nb:
   :args:
             - OCISvcCtx *svchp
             - OCIError *errhp
+            - ub4 flags
+
+# round trip: 1
+OCITransStart_nb:
+  :version: 800
+  :args:
+            - OCISvcCtx *svchp
+            - OCIError *errhp
+            - uword timeout
             - ub4 flags
 
 # round trip: 0 ?

--- a/ext/oci8/extconf.rb
+++ b/ext/oci8/extconf.rb
@@ -70,7 +70,9 @@ $objs = ["oci8lib.o", "env.o", "error.o", "oci8.o", "ocihandle.o",
          "stmt.o", "bind.o", "metadata.o", "attr.o",
          "lob.o", "oradate.o",
          "ocinumber.o", "ocidatetime.o", "object.o", "apiwrap.o",
-         "encoding.o", "oranumber_util.o", "thread_util.o", "util.o"]
+         "encoding.o", "oranumber_util.o", "thread_util.o",
+         "transaction.o",
+         "util.o"]
 
 if RUBY_PLATFORM =~ /mswin32|cygwin|mingw32|bccwin32/
   $defs << "-DUSE_WIN32_C"

--- a/ext/oci8/oci8.h
+++ b/ext/oci8/oci8.h
@@ -515,6 +515,10 @@ VALUE oci8_make_interval_ds(OCIInterval *s);
 /* object.c */
 void Init_oci_object(VALUE mOCI);
 
+/* transaction.c */
+void Init_oci8_transaction(VALUE cOCI8);
+extern const oci8_handle_data_type_t oci8_trans_data_type;
+
 /* attr.c */
 VALUE oci8_get_rowid_attr(oci8_base_t *base, ub4 attrtype, OCIStmt *stmtp);
 

--- a/ext/oci8/oci8lib.c
+++ b/ext/oci8/oci8lib.c
@@ -292,6 +292,7 @@ Init_oci8lib()
     Init_ora_date();
     Init_oci_datetime();
     Init_oci_object(cOCI8);
+    Init_oci8_transaction(cOCI8);
 
 #ifdef USE_WIN32_C
     Init_oci8_win32(cOCI8);

--- a/ext/oci8/transaction.c
+++ b/ext/oci8/transaction.c
@@ -1,0 +1,233 @@
+/* -*- c-file-style: "ruby"; indent-tabs-mode: nil -*- */
+/*
+ * transaction.c - part of ruby-oci8
+ *         implement the methods of OCI8::Transaction
+ *
+ * Copyright (C) 2019 Kubo Takehiro <kubo@jiubao.org>
+ *
+ */
+#include "oci8.h"
+#include "xa.h"
+
+static VALUE cOCI8Trans;
+static VALUE cOCI8Xid;
+
+#define TO_TRANS(obj) oci8_check_typeddata((obj), &oci8_trans_data_type, 1)
+
+static size_t xid_memsize(const void *ptr)
+{
+    return sizeof(XID);
+}
+
+static const rb_data_type_t xid_data_type = {
+    "OCI8::Xid",
+    {NULL, RUBY_DEFAULT_FREE, xid_memsize,},
+};
+
+static VALUE xid_alloc(VALUE klass)
+{
+    XID *xid;
+    return TypedData_Make_Struct(klass, XID, &xid_data_type, xid);
+}
+
+static VALUE xid_initialize(VALUE self, VALUE format_id, VALUE gtrid, VALUE bqual)
+{
+    XID *xid = RTYPEDDATA_DATA(self);
+    long fmtid = NUM2LONG(format_id);
+    long gtrid_length;
+    long bqual_length;
+
+    /* check gtrid */
+    StringValue(gtrid);
+    gtrid_length = RSTRING_LEN(gtrid);
+    if (gtrid_length < 1 || MAXGTRIDSIZE < gtrid_length) {
+        rb_raise(rb_eArgError, "Invalid length of global transaction id: %ld", gtrid_length);
+    }
+    /* check bqual */
+    StringValue(bqual);
+    bqual_length = RSTRING_LEN(bqual);
+    if (bqual_length < 1 || MAXBQUALSIZE < bqual_length) {
+        rb_raise(rb_eArgError, "Invalid length of branch qualifier: %ld", bqual_length);
+    }
+
+    xid->formatID = fmtid;
+    xid->gtrid_length = gtrid_length;
+    xid->bqual_length = bqual_length;
+    memcpy(xid->data, RSTRING_PTR(gtrid), gtrid_length);
+    memcpy(xid->data + gtrid_length, RSTRING_PTR(bqual), bqual_length);
+    return LONG2NUM(xid->formatID);
+}
+
+static VALUE xid_get_format_id(VALUE self)
+{
+    XID *xid = RTYPEDDATA_DATA(self);
+    return LONG2NUM(xid->formatID);
+}
+
+static VALUE xid_get_gtrid(VALUE self)
+{
+    XID *xid = RTYPEDDATA_DATA(self);
+    VALUE obj = rb_str_new(xid->data, xid->gtrid_length);
+    if (OBJ_TAINTED(self)) {
+        OBJ_TAINT(obj);
+    }
+    return obj;
+}
+
+static VALUE xid_get_bqual(VALUE self)
+{
+    XID *xid = RTYPEDDATA_DATA(self);
+    VALUE obj = rb_str_new(xid->data + xid->gtrid_length, xid->bqual_length);
+    if (OBJ_TAINTED(self)) {
+        OBJ_TAINT(obj);
+    }
+    return obj;
+}
+
+static VALUE xid_inspect(VALUE self)
+{
+    XID *xid = RTYPEDDATA_DATA(self);
+    char gtrid[128];
+    char bqual[128];
+    int i;
+#define TO_HEX(n) ((n) < 9 ? (n) + '0' : (n) - 10 + 'a')
+
+    for (i = 0; i < xid->gtrid_length; i++) {
+        char x = xid->data[i];
+        gtrid[i * 2 + 0] = TO_HEX((x >> 4) & 0x0F);
+        gtrid[i * 2 + 1] = TO_HEX((x >> 0) & 0x0F);
+    }
+    for (i = 0; i < xid->bqual_length; i++) {
+        char x = xid->data[xid->gtrid_length + i];
+        bqual[i * 2 + 0] = TO_HEX((x >> 4) & 0x0F);
+        bqual[i * 2 + 1] = TO_HEX((x >> 0) & 0x0F);
+    }
+    return rb_sprintf("<%s: %ld, %.*s, %.*s>",
+                      rb_obj_classname(self), xid->formatID,
+                      (int)xid->gtrid_length * 2, gtrid,
+                      (int)xid->bqual_length * 2, bqual);
+}
+
+const oci8_handle_data_type_t oci8_trans_data_type = {
+    {
+        "OCI8::TransHandle",
+        {
+            NULL,
+            oci8_handle_cleanup,
+            oci8_handle_size,
+        },
+        &oci8_handle_data_type.rb_data_type, NULL,
+#ifdef RUBY_TYPED_WB_PROTECTED
+        RUBY_TYPED_WB_PROTECTED,
+#endif
+    },
+    NULL,
+    sizeof(oci8_base_t),
+};
+
+static VALUE oci8_trans_alloc(VALUE klass)
+{
+    return oci8_allocate_typeddata(klass, &oci8_trans_data_type);
+}
+
+static VALUE oci8_trans_initialize(VALUE self)
+{
+    oci8_base_t *trans = TO_TRANS(self);
+    sword rv = OCIHandleAlloc(oci8_envhp, &trans->hp.ptr, OCI_HTYPE_TRANS, 0, NULL);
+    if (rv != OCI_SUCCESS)
+        oci8_env_raise(oci8_envhp, rv);
+    trans->type = OCI_HTYPE_TRANS;
+    return self;
+}
+
+static VALUE oci8_trans_get_name(VALUE self)
+{
+    oci8_base_t *trans = TO_TRANS(self);
+    char *value;
+    ub4 size = 0;
+    chkerr(OCIAttrGet(trans->hp.ptr, trans->type, &value, &size, OCI_ATTR_TRANS_NAME, oci8_errhp));
+    if (size == 0) {
+        return Qnil;
+    } else {
+        return rb_str_new(value, size);
+    }
+}
+
+static VALUE oci8_trans_get_timeout(VALUE self)
+{
+    oci8_base_t *trans = TO_TRANS(self);
+    ub4 value;
+    ub4 size = 0;
+    chkerr(OCIAttrGet(trans->hp.ptr, trans->type, &value, &size, OCI_ATTR_TRANS_TIMEOUT, oci8_errhp));
+    return UINT2NUM(value);
+}
+
+static VALUE oci8_trans_get_xid(VALUE self)
+{
+    oci8_base_t *trans = TO_TRANS(self);
+    void **value;
+    ub4 size = 0;
+    XID *xid;
+    VALUE obj;
+
+    chkerr(OCIAttrGet(trans->hp.ptr, trans->type, &value, &size, OCI_ATTR_XID, oci8_errhp));
+    obj = TypedData_Make_Struct(cOCI8Xid, XID, &xid_data_type, xid);
+    memcpy(xid, value, sizeof(XID));
+    return obj;
+}
+
+static VALUE oci8_trans_set_name(VALUE self, VALUE name)
+{
+    oci8_base_t *trans = TO_TRANS(self);
+    void *val = NULL;
+    ub4 size = 0;
+
+    if (!NIL_P(name)) {
+        SafeStringValue(name);
+        val = RSTRING_PTR(name);
+        size = RSTRING_LEN(name);
+    }
+    chkerr(OCIAttrSet(trans->hp.ptr, trans->type, val, size, OCI_ATTR_TRANS_NAME, oci8_errhp));
+    return self;
+}
+
+static VALUE oci8_trans_set_timeout(VALUE self, VALUE val)
+{
+    oci8_base_t *trans = TO_TRANS(self);
+    ub4 value = NUM2UINT(val);
+    chkerr(OCIAttrSet(trans->hp.ptr, trans->type, &value, sizeof(value), OCI_ATTR_TRANS_TIMEOUT, oci8_errhp));
+    return self;
+}
+
+static VALUE oci8_trans_set_xid(VALUE self, VALUE val)
+{
+    oci8_base_t *trans = TO_TRANS(self);
+    XID *xid;
+
+    if (!RTEST(rb_obj_is_kind_of(val, cOCI8Xid))) {
+        rb_raise(rb_eTypeError, "expect OCI8::Xid but %s", rb_class2name(CLASS_OF(val)));
+    }
+    xid = RTYPEDDATA_DATA(val);
+    chkerr(OCIAttrSet(trans->hp.ptr, trans->type, xid, sizeof(XID), OCI_ATTR_XID, oci8_errhp));
+    return self;
+}
+
+void Init_oci8_transaction(VALUE cOCI8)
+{
+    cOCI8Xid = rb_define_class_under(cOCI8, "Xid", rb_cObject);
+    rb_define_alloc_func(cOCI8Xid, xid_alloc);
+    rb_define_method(cOCI8Xid, "initialize", xid_initialize, 3);
+    rb_define_method(cOCI8Xid, "format_id", xid_get_format_id, 0);
+    rb_define_method(cOCI8Xid, "gtrid", xid_get_gtrid, 0);
+    rb_define_method(cOCI8Xid, "bqual", xid_get_bqual, 0);
+    rb_define_method(cOCI8Xid, "inspect", xid_inspect, 0);
+
+    cOCI8Trans = oci8_define_class_under(cOCI8, "TransHandle", &oci8_trans_data_type, oci8_trans_alloc);
+    rb_define_method(cOCI8Trans, "initialize", oci8_trans_initialize, 0);
+    rb_define_method(cOCI8Trans, "name", oci8_trans_get_name, 0);
+    rb_define_method(cOCI8Trans, "timeout", oci8_trans_get_timeout, 0);
+    rb_define_method(cOCI8Trans, "xid", oci8_trans_get_xid, 0);
+    rb_define_method(cOCI8Trans, "name=", oci8_trans_set_name, 1);
+    rb_define_method(cOCI8Trans, "timeout=", oci8_trans_set_timeout, 1);
+    rb_define_method(cOCI8Trans, "xid=", oci8_trans_set_xid, 1);
+}


### PR DESCRIPTION
@tomasjura 
This is a one-to-one mapping. I won't merge it because it isn't easy-to-use and some methods' usages are obscure for me.

The following classes and methods are added.
* `OCI8::Xid` - a mapping of XID structure defined in xa.h.
  * `#new(format_id, gtrid, bqual)` - creates a new Xid instance using format id, global transaction id and branch qualifier.
     C code:
     ```c
     /* start a transaction with global transaction id = [1000, 123, 1] */
    gxid.formatID = 1000; /* format id = 1000 */
    gxid.gtrid_length = 3; /* gtrid = 123 */
    gxid.data[0] = 1; gxid.data[1] = 2; gxid.data[2] = 3;
    gxid.bqual_length = 1; /* bqual = 1 */
    gxid.data[3] = 1;
    ```
    ruby code:
    ```ruby
    xid = OCI8::Xid.new(1000, "\x01\x02\x03", "\x01")
    ```
  * `#format_id` - gets format id as Integer.
  * `#gtrid` - gets global transaction id as ASCII-8bit String.
  * `#bqual` - gets branch qualifier as ASCII-8bit String.

* `OCI8::TransHandle` - a mapping of transaction handle.
  * `#new` - creates a new transaction handle by `OCIHandleAlloc(envhp, (void  **)&handle,  OCI_HTYPE_TRANS, 0, 0)`
  * `#name=string` - sets the string value to the [OCI_ATTR_TRANS_NAME][] attribute.
  * `#name` - gets the [OCI_ATTR_TRANS_NAME][] attribute.  As far as I checked, it seems same with `#xid.gtrid`
  * `#timeout=integer`- sets the integer value to the [OCI_ATTR_TRANS_TIMEOUT][] attrbiute.
  * `#timeout`- gets the [OCI_ATTR_TRANS_TIMEOUT][] attrbiute. As far as I checked, it seems always zero.
  * `#xid=xid` - sets the xid value, which must be an instance of `OCI8::Xid`, to the [OCI_ATTR_XID] attribute
  * `#xid` - gets the [OCI_ATTR_XID] attribute as `OCI8::Xid`

* `OCI8` - connection
  * `#trans_handle=handle` - sets the transaction handle
    It corresponds to `OCIAttrSet(svchp, OCI_HTYPE_SVCCTX, txnhp, 0, OCI_ATTR_TRANS, errhp)`. The handle is set to `@trans_handle` instance variable of `self` also in order to prevent it from being freed by GC.
  * `#trans_handle` - gets the transaction handle set by `#trans_handle=`.
  * `#commit(flag...)` - calls [OCITransCommit][].
    Flags are specified by symbol.
     ```ruby
     conn.commit   # no flags are specified.
     ...
     conn.commit(:two_phase) # :two_phase <= OCI_TRANS_TWOPHASE
     ```
  * `#trans_detach` - calls [OCITransDetach][].
  * `#trans_forget` - calls [OCITransForget][]. 
  * `#trans_prepare` - calls [OCITransPrepare][]. It returns `true` when the transaction must be committed by `conn.commit(:two_phase)`. `false` when `ORA-24767: transaction branch prepare returns read-only`.
  * `#trans_start(timeout, flag...)` - calls [OCITransStart][].
    Flags are specified by symbol. 
     ```ruby
     conn.trans_start(10, :new, :tight)  # : new <= OCI_TRANS_NEW, :tight <= OCI_TRANS_TIGHT
     ```

[OCI_ATTR_TRANS_NAME]: https://docs.oracle.com/en/database/oracle/oracle-database/19/lnoci/handle-and-descriptor-attributes.html#GUID-C794ECF3-8832-43D8-A889-423B159E06E7
[OCI_ATTR_TRANS_TIMEOUT]: https://docs.oracle.com/en/database/oracle/oracle-database/19/lnoci/handle-and-descriptor-attributes.html#GUID-C794ECF3-8832-43D8-A889-423B159E06E7__GUID-4D067F9D-736C-4A77-BA92-2E0E92235B1D
[OCI_ATTR_XID]: https://docs.oracle.com/en/database/oracle/oracle-database/19/lnoci/handle-and-descriptor-attributes.html#GUID-C794ECF3-8832-43D8-A889-423B159E06E7__GUID-D1578630-633A-4340-B45D-0B1B63A1D095

[OCITransStart]: https://docs.oracle.com/en/database/oracle/oracle-database/19/lnoci/transaction-functions.html#GUID-81E5963B-4DE7-47E1-ABB0-C1490AF3BAA8
[OCITransDetach]: https://docs.oracle.com/en/database/oracle/oracle-database/19/lnoci/transaction-functions.html#GUID-03AB7BAB-C8F0-4DFF-BD10-7CE0F3C8CE09
[OCITransForget]: https://docs.oracle.com/en/database/oracle/oracle-database/19/lnoci/transaction-functions.html#GUID-1BBB1A11-66F5-424D-B0CA-8034085C7E00
[OCITransPrepare]: https://docs.oracle.com/en/database/oracle/oracle-database/19/lnoci/transaction-functions.html#GUID-B8ADEE8D-9A5F-48C6-A862-4FFE280BA0D3
[OCITransCommit]: https://docs.oracle.com/en/database/oracle/oracle-database/19/lnoci/transaction-functions.html#GUID-DDAE3122-8769-4A30-8D78-EB2A3CCF77D4
