### PR TITLE
Use `File.exist?` instead of removed `File.exists?` in Ruby 3.2

### DIFF
--- a/ext/oci8/oraconf.rb
+++ b/ext/oci8/oraconf.rb
@@ -535,7 +535,7 @@ EOS
                   # No need to check the real path.
                   # The current instant client doesn't use @rpath or @loader_path.
                 when /\/libclntsh\.dylib/, /\/libnnz\d\d.dylib/
-                  raise <<EOS unless File.exists?(libname)
+                  raise <<EOS unless File.exist?(libname)
 The output of "otool -L #{file}" is:
   | #{IO.readlines("|otool -L #{file}").join('  | ')}
 Ruby-oci8 doesn't work without DYLD_LIBRARY_PATH or DYLD_FALLBACK_LIBRARY_PATH
@@ -1061,7 +1061,7 @@ EOS
     # check inc_dir
     inc_dirs = inc_dir.split(File::PATH_SEPARATOR)
     ociinc = inc_dirs.find do |dir|
-      File.exists?("#{dir}/oci.h")
+      File.exist?("#{dir}/oci.h")
     end
     unless ociinc
           raise <<EOS

--- a/ruby-oci8.gemspec
+++ b/ruby-oci8.gemspec
@@ -50,7 +50,7 @@ EOS
     # add map files to analyze a core (minidump) file.
     so_vers.each do |ver|
       map_file = 'ext/oci8/oci8lib_#{ver}.map'
-      so_files << map_file if File.exists? map_file
+      so_files << map_file if File.exist? map_file
     end
 
     # least version in so_vers


### PR DESCRIPTION
Ruby 3.2 removes deprecated `File.exists?` method via https://github.com/ruby/ruby/pull/5352

- This commit addresses this error.

```ruby
$ ruby -v
ruby 3.2.0dev (2021-12-29T00:37:59Z master d75f7078c8) [x86_64-linux]
$ ruby setup.rb config
---> lib
---> lib/oci8
<--- lib/oci8
---> lib/dbd
<--- lib/dbd
<--- lib
---> ext
---> ext/oci8
/home/yahonda/.rbenv/versions/3.2.0-dev/bin/ruby /home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/extconf.rb
attempting to locate oracle-instantclient...
checking load library path...
  LD_LIBRARY_PATH...
    checking /usr/lib/oracle/21/client64/lib... yes
  /usr/lib/oracle/21/client64/lib/libclntsh.so.10.1 looks like an instant client.
checking for cc... ok
checking for gcc... yes
checking for LP64... yes
checking for sys/types.h... yes
checking for ruby header... ok
---------------------------------------------------
Error Message:
  undefined method `exists?' for File:Class

        File.exists?("#{dir}/oci.h")
            ^^^^^^^^
  Did you mean?  exist?
Backtrace:
  /home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/oraconf.rb:1064:in `block in initialize'
  /home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/oraconf.rb:1063:in `each'
  /home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/oraconf.rb:1063:in `find'
  /home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/oraconf.rb:1063:in `initialize'
  /home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/oraconf.rb:271:in `new'
  /home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/oraconf.rb:271:in `get'
  /home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/extconf.rb:22:in `<main>'
---------------------------------------------------
See:
 * http://www.rubydoc.info/github/kubo/ruby-oci8/file/docs/install-full-client.md for Oracle full client
 * http://www.rubydoc.info/github/kubo/ruby-oci8/file/docs/install-instant-client.md for Oracle instant client
 * http://www.rubydoc.info/github/kubo/ruby-oci8/file/docs/install-on-osx.md for OS X
 * http://www.rubydoc.info/github/kubo/ruby-oci8/file/docs/report-installation-issue.md to report an issue.

/home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/oraconf.rb:1064:in `block in initialize': RuntimeError (RuntimeError)
	from /home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/oraconf.rb:1063:in `each'
	from /home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/oraconf.rb:1063:in `find'
	from /home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/oraconf.rb:1063:in `initialize'
	from /home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/oraconf.rb:271:in `new'
	from /home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/oraconf.rb:271:in `get'
	from /home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/extconf.rb:22:in `<main>'
/home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/oraconf.rb:1064:in `block in initialize': undefined method `exists?' for File:Class (NoMethodError)

      File.exists?("#{dir}/oci.h")
          ^^^^^^^^
Did you mean?  exist?
	from /home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/oraconf.rb:1063:in `each'
	from /home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/oraconf.rb:1063:in `find'
	from /home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/oraconf.rb:1063:in `initialize'
	from /home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/oraconf.rb:271:in `new'
	from /home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/oraconf.rb:271:in `get'
	from /home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/extconf.rb:22:in `<main>'
'system /home/yahonda/.rbenv/versions/3.2.0-dev/bin/ruby /home/yahonda/src/github.com/kubo/ruby-oci8/ext/oci8/extconf.rb ' failed
Try 'ruby setup.rb --help' for detailed usage.
$
```

* These files are auto-corrected by RuboCop as follows.
```ruby
$ rubocop -v
1.24.0
$ rubocop --only Lint/DeprecatedClassMethods -a
Inspecting 53 files
..W....................W.............................

Offenses:

ext/oci8/oraconf.rb:538:43: W: [Corrected] Lint/DeprecatedClassMethods: File.exists? is deprecated in favor of File.exist?.
                  raise <<EOS unless File.exists?(libname)
                                          ^^^^^^^
ext/oci8/oraconf.rb:1064:12: W: [Corrected] Lint/DeprecatedClassMethods: File.exists? is deprecated in favor of File.exist?.
      File.exists?("#{dir}/oci.h")
           ^^^^^^^
ruby-oci8.gemspec:53:36: W: [Corrected] Lint/DeprecatedClassMethods: File.exists? is deprecated in favor of File.exist?.
      so_files << map_file if File.exists? map_file
                                   ^^^^^^^

53 files inspected, 3 offenses detected, 3 offenses corrected
$
```
