### PR TITLE
Add TruffleRuby to CI with continue-on-error

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,10 +2,15 @@ name: Tests
 on: [push, pull_request]
 jobs:
   tests:
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         ruby: [2.5, 2.6, 2.7, '3.0', 3.1]
+        experimental: [false]
+        include:
+          - ruby: 'truffleruby-head'
+            experimental: true
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
I am proposing this as a solution to the transient errors mentioned in: https://github.com/kubo/ruby-oci8/pull/245

This would allow the `truffleruby-head` to fail silently. The TruffleRuby team monitors these failures regularly using the tracker here: https://github.com/eregon/truffleruby-gem-tracker.

This configuration is documented here: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error