### PR TITLE
Force encoding via `force_string_encoding` property

### DIFF
--- a/docs/working-with-legacy-encodings.md
+++ b/docs/working-with-legacy-encodings.md
@@ -1,0 +1,30 @@
+# @title Working with Legacy Encodings
+
+Working with Legacy Encodings
+==================
+
+The following parameters are available since ruby-oci8 2.2.11.
+
+* force_string_encoding
+
+For example:
+
+    OCI8.properties[:force_string_encoding] = true
+
+Today, the default encoding for Ruby and Rails applications is UTF-8. This can be a problem for applications with older Oracle databases, which are encoded in much narrower character sets like ASCII.
+
+For applications that want to maintain UTF-8 compatibility in spite of an ASCII-encoded database, they may want to force UTF-8 strings into ASCII for persistence, and then take on the responsiblity of re-encoding those strings into UTF-8 on read:
+
+```
+> val = "“Who thought smart quotes were a good idea?!”"
+=> "“Who thought smart quotes were a good idea?!”"
+> val = val.force_encoding Encoding::ASCII
+=> "\xE2\x80\x9CWho thought smart quotes were a good idea?!\xE2\x80\x9D"
+> ::ActiveSupport::Multibyte.proxy_class.new(val).tidy_bytes.to_s
+=> "“Who thought smart quotes were a good idea?!”"
+```
+
+Normally, a string with an encoding that does not match that of Oracle/OCI8 would raise an `Encoding::UndefinedConversionError`.  By setting `force_string_encoding` to `true`, the application will have strings unmatched strings take on that endcoding regardless.
+
+See also:
+[gigo](https://github.com/customink/gigo) - gem that converts improperly-encoded strings with escaped characters to their proper encoding.

--- a/lib/oci8/bindtype.rb
+++ b/lib/oci8/bindtype.rb
@@ -118,7 +118,7 @@ class OCI8
                 if OCI8.encoding != val.encoding
                   # If the string encoding is different with NLS_LANG character set,
                   # convert it to get the length.
-                  val = val.encode(OCI8.encoding)
+                  val = OCI8.properties[:force_string_encoding] ? val.force_encoding(OCI8.encoding) : val.encode(OCI8.encoding)
                 end
                 param[:length] = val.bytesize
               end

--- a/lib/oci8/properties.rb
+++ b/lib/oci8/properties.rb
@@ -19,6 +19,7 @@ class OCI8
     :recv_timeout => nil,
     :tcp_keepalive => false,
     :tcp_keepalive_time => nil,
+    :force_string_encoding => false,
   }
 
   # @private
@@ -72,6 +73,8 @@ class OCI8
         raise ArgumentError, "The property value for :#{name} must be nil or a positive integer." if val <= 0
       end
       OCI8.__set_prop(4, val)
+    when :force_string_encoding
+      val = val ? true : false
     end
     super(name, val)
   end
@@ -186,6 +189,12 @@ class OCI8
   #     See {file:docs/hanging-after-inactivity.md}
   #
   #     *Since:* 2.2.4
+  #
+  # [:force_string_encoding]
+  #
+  #     See {file:docs/working-with-legacy-encodings.md}
+  #
+  #     *Since:* 2.2.12
   #
   # @return [a customized Hash]
   # @since 2.0.5


### PR DESCRIPTION
When creating string bindings, use `String#force_encoding`, instead of `String#encode`, via the `force_string_encoding` property.

My intent here is to allow the writing of UTF-8 strings to legacy encoding types without monkey-patching `ruby-oci8`.

Backstory: we have a large, old Oracle database with ASCII encoding. It's huge and Oracle is deprecated for us, so we're not taking on the maintenance to move these to UTF-8. What we've done instead is patch `ruby-oci8` so we can persist our escaped UTF-8 strings in ASCII, then use [ActiveSupport::Multibyte#tidy_bytes](https://apidock.com/rails/v5.2.3/ActiveSupport/Multibyte/Unicode/tidy_bytes) to convert them back to UTF-8 on read.

I know this is probably an uncommon need at this point, so if there isn't sufficient utility in such a flag or there are other reasons not to add such a feature, let me know.