### PR TITLE
Make OCIError a type of Error

### DIFF
--- a/lib/oci8/oci8.rb
+++ b/lib/oci8/oci8.rb
@@ -585,7 +585,7 @@ class OCI8
   end
 end
 
-class OCIError
+class OCIError < StandardError
 
   # @overload initialize(message, error_code = nil, sql_stmt = nil, parse_error_offset = nil)
   #   Creates a new OCIError object with specified parameters.
@@ -617,7 +617,7 @@ class OCIError
   #     # => #<OCIError: ORA-04043: object %s does not exist>
   #     # When NLS_LANG=german_germany.AL32UTF8
   #     # => #<OCIError: ORA-04043: Objekt %s ist nicht vorhanden>
-  #     
+  #
   #     # with one parameter
   #     OCIError.new(4043, 'table_name')
   #     # When NLS_LANG=american_america.AL32UTF8


### PR DESCRIPTION
I'm in the process of creating an [OpenTelemetry](https://opentelemetry.io/) Gem for `ruby-oci8`. One of the things that's adding a lot of complication is the fact that `OCIError` isn't any type of Error, it's just a basic Class.

This PR changes `OCIError` to inherit from `StandardError`. This should make it easier for tools to catch and do something with them when they're raised.